### PR TITLE
Add migration and documentation for ranking schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ npm start
 - Keep your Supabase keys private—never commit `.env.local` to version control.
 - If you update authentication settings (such as enabling social providers), the homepage form will work automatically with
   those providers as long as they are enabled in Supabase.
+- Database tables that store ranking metadata are documented in [docs/ranking-schema.md](docs/ranking-schema.md) along with a
+  migration script you can run against your Supabase project.

--- a/docs/ranking-schema.md
+++ b/docs/ranking-schema.md
@@ -1,0 +1,110 @@
+# Ranking Database Schema
+
+This document describes the database objects that power shared Elo rankings for arbitrary item types. The schema is designed
+for PostgreSQL (and Supabase) and is applied by the migration located at
+`./supabase/migrations/20240509000000_create_ranking_schema.sql`.
+
+## Overview
+
+The schema introduces a generalized workflow:
+
+1. **Item Types** (`item_types`) capture each category of content that can be ranked (movies, books, albums, etc.).
+2. **Rankable Items** (`rankable_items`) store the canonical information for every item that could appear in a ranking.
+3. **Ranking Groups** (`ranking_groups`) represent user-created collections that scope Elo comparisons to a single item type.
+4. **Group Items** (`group_items`) enumerate the items assigned to a particular ranking group.
+5. **Group Participants** (`group_participants`) track membership so the application knows which users can submit comparisons.
+6. **User Group Item Ratings** (`user_group_item_ratings`) store the Elo score each participant has built up for every item in a
+   group.
+
+The diagram below summarizes the relationships:
+
+```mermaid
+erDiagram
+  item_types ||--o{ rankable_items : "categorizes"
+  item_types ||--o{ ranking_groups : "scopes"
+  ranking_groups ||--o{ group_items : "contains"
+  rankable_items ||--o{ group_items : "listed"
+  ranking_groups ||--o{ group_participants : "has"
+  ranking_groups ||--o{ user_group_item_ratings : "rates"
+  group_participants ||--o{ user_group_item_ratings : "contributes"
+  rankable_items ||--o{ user_group_item_ratings : "scored"
+```
+
+> **Note:** User identifiers (`creator_id`, `user_id`) reference your external authentication system. They are stored as UUIDs
+> so they can map directly to Supabase Auth users.
+
+## Table reference
+
+### `item_types`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `serial` | Surrogate primary key. |
+| `name` | `varchar(255)` | Human-readable label. Must be unique. |
+| `slug` | `varchar(255)` | URL-safe identifier (lowercase with hyphens recommended). Must be unique. |
+
+### `rankable_items`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `serial` | Surrogate primary key. |
+| `item_type_id` | `integer` | Foreign key to `item_types.id` with `ON DELETE RESTRICT`. |
+| `external_id` | `varchar(255)` | Optional unique identifier from a third-party API. |
+| `name` | `varchar(255)` | Display name for the item. |
+| `image_path` | `varchar(1024)` | Optional relative or absolute path to artwork. |
+| `metadata` | `jsonb` | Optional JSON payload for additional structured attributes. |
+
+An index on `item_type_id` accelerates lookups when pulling all items for a given category.
+
+### `ranking_groups`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key generated with `gen_random_uuid()`. |
+| `name` | `varchar(255)` | Required name of the group. |
+| `description` | `text` | Optional long-form explanation shown to participants. |
+| `creator_id` | `uuid` | References the creating user in the external auth system. |
+| `item_type_id` | `integer` | Foreign key to `item_types.id` with `ON DELETE RESTRICT`. |
+| `created_at` | `timestamptz` | Defaults to the current UTC timestamp. |
+
+### `group_items`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `group_id` | `uuid` | Foreign key to `ranking_groups.id` with `ON DELETE CASCADE`. |
+| `item_id` | `integer` | Foreign key to `rankable_items.id` with `ON DELETE CASCADE`. |
+
+The composite primary key `(group_id, item_id)` ensures that items are listed only once per group.
+
+### `group_participants`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `user_id` | `uuid` | Identifier for the participant in the external auth system. |
+| `group_id` | `uuid` | Foreign key to `ranking_groups.id` with `ON DELETE CASCADE`. |
+| `joined_at` | `timestamptz` | Defaults to the current UTC timestamp. |
+
+The composite primary key `(user_id, group_id)` prevents duplicate memberships.
+
+### `user_group_item_ratings`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `user_id` | `uuid` | Participant identifier. |
+| `group_id` | `uuid` | Foreign key to `ranking_groups.id` with `ON DELETE CASCADE`. |
+| `item_id` | `integer` | Foreign key to `rankable_items.id` with `ON DELETE CASCADE`. |
+| `rating` | `numeric(10,4)` | Elo rating maintained per user/group/item trio. |
+| `comparison_count` | `integer` | Number of comparisons made; defaults to `0`. |
+
+Additional indexes on `group_id` and `item_id` support aggregate queries (e.g., leaderboards) without requiring a table scan.
+
+## Applying the migration
+
+Run the migration against your PostgreSQL database (or Supabase project) using your preferred tooling. With `psql` the command
+looks like:
+
+```bash
+psql "$DATABASE_URL" -f supabase/migrations/20240509000000_create_ranking_schema.sql
+```
+
+After running the script you can verify the schema by inspecting the tables listed above.

--- a/supabase/migrations/20240509000000_create_ranking_schema.sql
+++ b/supabase/migrations/20240509000000_create_ranking_schema.sql
@@ -1,0 +1,90 @@
+-- Migration: Create ranking schema tables
+-- Description: Establish tables to support generic rankable items and group-based Elo ratings.
+
+set statement_timeout = 0;
+set lock_timeout = 0;
+set idle_in_transaction_session_timeout = 0;
+set client_encoding = 'UTF8';
+set standard_conforming_strings = on;
+set check_function_bodies = false;
+set client_min_messages = warning;
+set row_security = off;
+
+create schema if not exists public;
+
+create extension if not exists "pgcrypto" with schema public;
+
+create table if not exists public.item_types (
+  id serial primary key,
+  name varchar(255) not null unique,
+  slug varchar(255) not null unique
+);
+
+comment on table public.item_types is 'Categories of items that can be ranked (e.g., Movie, Book).';
+comment on column public.item_types.name is 'Display name for the item category.';
+comment on column public.item_types.slug is 'URL-friendly identifier for the item category.';
+
+create table if not exists public.rankable_items (
+  id serial primary key,
+  item_type_id integer not null references public.item_types(id) on delete restrict,
+  external_id varchar(255) unique,
+  name varchar(255) not null,
+  image_path varchar(1024),
+  metadata jsonb
+);
+
+comment on table public.rankable_items is 'Library of individual items that can be ranked across all categories.';
+comment on column public.rankable_items.item_type_id is 'Foreign key to item_types indicating the category of the item.';
+comment on column public.rankable_items.external_id is 'Optional ID from an external provider (e.g., TMDb).';
+comment on column public.rankable_items.metadata is 'Optional JSON payload for auxiliary data such as release year or author.';
+
+create table if not exists public.ranking_groups (
+  id uuid primary key default gen_random_uuid(),
+  name varchar(255) not null,
+  description text,
+  creator_id uuid not null,
+  item_type_id integer not null references public.item_types(id) on delete restrict,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+comment on table public.ranking_groups is 'User-created collections of rankable items scoped to a single item type.';
+comment on column public.ranking_groups.creator_id is 'Identifier for the user who created the group (stored in an external auth system).';
+comment on column public.ranking_groups.item_type_id is 'Ensures the group only contains items from a single item type.';
+
+create table if not exists public.group_items (
+  group_id uuid not null references public.ranking_groups(id) on delete cascade,
+  item_id integer not null references public.rankable_items(id) on delete cascade,
+  primary key (group_id, item_id)
+);
+
+comment on table public.group_items is 'Join table connecting ranking groups to the items they include.';
+
+create table if not exists public.group_participants (
+  user_id uuid not null,
+  group_id uuid not null references public.ranking_groups(id) on delete cascade,
+  joined_at timestamptz not null default timezone('utc', now()),
+  primary key (user_id, group_id)
+);
+
+comment on table public.group_participants is 'Tracks which users participate in each ranking group.';
+comment on column public.group_participants.user_id is 'Identifier for the participating user (stored in an external auth system).';
+
+create table if not exists public.user_group_item_ratings (
+  user_id uuid not null,
+  group_id uuid not null references public.ranking_groups(id) on delete cascade,
+  item_id integer not null references public.rankable_items(id) on delete cascade,
+  rating numeric(10,4) not null,
+  comparison_count integer not null default 0,
+  primary key (user_id, group_id, item_id)
+);
+
+comment on table public.user_group_item_ratings is 'Elo rating data for a given user, item, and ranking group context.';
+comment on column public.user_group_item_ratings.rating is 'Current Elo rating for the item within the user''s group context.';
+comment on column public.user_group_item_ratings.comparison_count is 'How many head-to-head comparisons the user has logged for the item.';
+
+create index if not exists rankable_items_item_type_id_idx on public.rankable_items (item_type_id);
+create index if not exists ranking_groups_item_type_id_idx on public.ranking_groups (item_type_id);
+create index if not exists group_items_item_id_idx on public.group_items (item_id);
+create index if not exists group_participants_group_id_idx on public.group_participants (group_id);
+create index if not exists user_group_item_ratings_group_id_idx on public.user_group_item_ratings (group_id);
+create index if not exists user_group_item_ratings_item_id_idx on public.user_group_item_ratings (item_id);


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the item, group, and Elo rating tables that back shared rankings
- document each table and relationship in a new docs/ranking-schema.md guide and link it from the README

## Testing
- not run (documentation and SQL only)


------
https://chatgpt.com/codex/tasks/task_e_68d0b7a009e8832e974ca40103b65523