### PR TITLE
Add movies library page with TMDb poster support

### DIFF
--- a/app/api/movies/bulk-upload/route.ts
+++ b/app/api/movies/bulk-upload/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import Papa, { ParseError } from 'papaparse';
 
 import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+import { getMovieItemTypeId } from '@/lib/itemTypes';
 
 type CsvRow = Record<string, string | undefined>;
 
@@ -122,37 +123,6 @@ const fetchTmdbMovie = async (name: string, year: number | undefined, apiKey: st
   const [match] = payload.results ?? [];
 
   return match ?? null;
-};
-
-const getMovieItemTypeId = async (): Promise<number> => {
-  const { data: existingType, error: existingError } = await supabaseAdminClient
-    .from('item_types')
-    .select('id')
-    .eq('slug', 'movie')
-    .maybeSingle();
-
-  if (existingError) {
-    throw existingError;
-  }
-
-  if (existingType) {
-    return existingType.id;
-  }
-
-  const { data: insertedType, error: insertError } = await supabaseAdminClient
-    .from('item_types')
-    .upsert({
-      name: 'Movie',
-      slug: 'movie',
-    }, { onConflict: 'slug' })
-    .select('id')
-    .single();
-
-  if (insertError) {
-    throw insertError;
-  }
-
-  return insertedType.id;
 };
 
 export async function POST(request: NextRequest) {

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,0 +1,117 @@
+import Image from 'next/image';
+
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+import { getMovieItemTypeId } from '@/lib/itemTypes';
+import { buildPosterUrl, getTmdbConfiguration } from '@/lib/tmdb';
+
+export const revalidate = 0;
+
+const MOVIE_POSTER_SIZE = 'w342';
+
+type MovieRow = {
+  id: number;
+  name: string;
+  image_path: string | null;
+  metadata: Record<string, unknown> | null;
+};
+
+const parseReleaseYear = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const typedMetadata = metadata as {
+    tmdb?: { release_date?: string | null };
+    release_date?: string | null;
+    releaseDate?: string | null;
+  };
+
+  const releaseDate =
+    typedMetadata.tmdb?.release_date ?? typedMetadata.release_date ?? typedMetadata.releaseDate;
+
+  if (typeof releaseDate !== 'string' || releaseDate.length < 4) {
+    return null;
+  }
+
+  return releaseDate.slice(0, 4);
+};
+
+const fetchMovies = async () => {
+  const movieItemTypeId = await getMovieItemTypeId();
+
+  const { data, error } = await supabaseAdminClient
+    .from<MovieRow>('rankable_items')
+    .select('id, name, image_path, metadata')
+    .eq('item_type_id', movieItemTypeId)
+    .order('name', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? [];
+};
+
+export default async function MoviesPage() {
+  const [movies, tmdbConfig] = await Promise.all([fetchMovies(), getTmdbConfiguration()]);
+
+  const moviesWithPosters = movies.map((movie) => ({
+    ...movie,
+    posterUrl: buildPosterUrl(tmdbConfig, movie.image_path, MOVIE_POSTER_SIZE),
+    releaseYear: parseReleaseYear(movie.metadata ?? null),
+  }));
+
+  return (
+    <main className="min-h-screen bg-gray-900 px-6 py-12 text-white">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <header className="flex flex-col gap-4 text-center sm:text-left">
+          <h1 className="text-4xl font-bold sm:text-5xl">Movie Library</h1>
+          <p className="text-lg text-gray-300">
+            Browse every movie that&apos;s currently available for head-to-head rankings.
+          </p>
+        </header>
+
+        {moviesWithPosters.length === 0 ? (
+          <p className="text-center text-gray-300 sm:text-left">
+            No movies have been added yet. Upload a CSV to start building the library.
+          </p>
+        ) : (
+          <ul className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {moviesWithPosters.map((movie) => (
+              <li
+                key={movie.id}
+                className="flex flex-col rounded-lg border border-gray-800 bg-gray-950/60 p-4 shadow-lg shadow-black/30"
+              >
+                <div className="flex justify-center">
+                  {movie.posterUrl ? (
+                    <Image
+                      src={movie.posterUrl}
+                      alt={`${movie.name} poster`}
+                      width={342}
+                      height={513}
+                      className="h-auto w-48 rounded-md object-cover shadow-md shadow-black/50 sm:w-60"
+                      sizes="(max-width: 640px) 12rem, (max-width: 1024px) 15rem, 20rem"
+                    />
+                  ) : (
+                    <div className="flex h-72 w-48 items-center justify-center rounded-md bg-gray-800 text-sm text-gray-400 sm:w-60">
+                      Poster unavailable
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-6 flex flex-col gap-2 text-center sm:text-left">
+                  <h2 className="text-2xl font-semibold text-white">{movie.name}</h2>
+                  {movie.releaseYear ? (
+                    <p className="text-gray-400">Released {movie.releaseYear}</p>
+                  ) : (
+                    <p className="text-gray-500">Release year unknown</p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -40,7 +40,7 @@ const fetchMovies = async () => {
   const movieItemTypeId = await getMovieItemTypeId();
 
   const { data, error } = await supabaseAdminClient
-    .from<MovieRow>('rankable_items')
+    .from('rankable_items')
     .select('id, name, image_path, metadata')
     .eq('item_type_id', movieItemTypeId)
     .order('name', { ascending: true });
@@ -49,7 +49,7 @@ const fetchMovies = async () => {
     throw error;
   }
 
-  return data ?? [];
+  return (data ?? []) as MovieRow[];
 };
 
 export default async function MoviesPage() {

--- a/lib/itemTypes.ts
+++ b/lib/itemTypes.ts
@@ -1,0 +1,39 @@
+import { cache } from 'react';
+
+import { supabaseAdminClient } from './supabaseAdminClient';
+
+const MOVIE_SLUG = 'movie';
+
+export const getMovieItemTypeId = cache(async (): Promise<number> => {
+  const { data: existingType, error: existingError } = await supabaseAdminClient
+    .from('item_types')
+    .select('id')
+    .eq('slug', MOVIE_SLUG)
+    .maybeSingle();
+
+  if (existingError) {
+    throw existingError;
+  }
+
+  if (existingType) {
+    return existingType.id;
+  }
+
+  const { data: insertedType, error: insertError } = await supabaseAdminClient
+    .from('item_types')
+    .upsert(
+      {
+        name: 'Movie',
+        slug: MOVIE_SLUG,
+      },
+      { onConflict: 'slug' }
+    )
+    .select('id')
+    .single();
+
+  if (insertError) {
+    throw insertError;
+  }
+
+  return insertedType.id;
+});

--- a/lib/tmdb.ts
+++ b/lib/tmdb.ts
@@ -1,0 +1,86 @@
+import { cache } from 'react';
+
+const TMDB_CONFIGURATION_URL = 'https://api.themoviedb.org/3/configuration';
+
+export type TmdbImageConfiguration = {
+  base_url: string;
+  secure_base_url: string;
+  backdrop_sizes: string[];
+  logo_sizes: string[];
+  poster_sizes: string[];
+  profile_sizes: string[];
+  still_sizes: string[];
+};
+
+export type TmdbConfigurationResponse = {
+  images: TmdbImageConfiguration;
+};
+
+export const getTmdbConfiguration = cache(async (): Promise<TmdbConfigurationResponse> => {
+  const apiKey = process.env.TMDB_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('TMDB_API_KEY environment variable is not configured.');
+  }
+
+  const url = new URL(TMDB_CONFIGURATION_URL);
+  url.searchParams.set('api_key', apiKey);
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+    },
+    next: { revalidate: 60 * 60 * 24 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`TMDb configuration request failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as TmdbConfigurationResponse;
+
+  if (!payload.images) {
+    throw new Error('TMDb configuration response did not include image settings.');
+  }
+
+  return payload;
+});
+
+const selectPosterSize = (posterSizes: string[], preferredSize: string) => {
+  if (posterSizes.includes(preferredSize)) {
+    return preferredSize;
+  }
+
+  if (posterSizes.includes('original')) {
+    return 'original';
+  }
+
+  return posterSizes.at(-1) ?? '';
+};
+
+export const buildPosterUrl = (
+  config: TmdbConfigurationResponse,
+  posterPath: string | null | undefined,
+  preferredSize = 'w342'
+): string | null => {
+  if (!posterPath) {
+    return null;
+  }
+
+  const { images } = config;
+  const baseUrl = images.secure_base_url || images.base_url;
+
+  if (!baseUrl) {
+    return null;
+  }
+
+  const normalizedSize = selectPosterSize(images.poster_sizes ?? [], preferredSize);
+
+  if (!normalizedSize) {
+    return null;
+  }
+
+  const normalizedPath = posterPath.startsWith('/') ? posterPath : `/${posterPath}`;
+
+  return `${baseUrl}${normalizedSize}${normalizedPath}`;
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'image.tmdb.org',
+        pathname: '/t/p/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a /movies page that lists stored movie rankable items with their poster art
- fetch and cache the TMDb configuration to build full poster URLs from stored image paths
- share the helper for resolving the movie item type and allow Next.js Image to load TMDb posters

## Testing
- npm run build *(fails: Next.js font downloads are blocked in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1628151cc832e9cdb088738d6f173