### PR TITLE
feat: add movie ranking group builder

### DIFF
--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -1,0 +1,176 @@
+import { NextResponse } from 'next/server';
+
+import { getMovieItemTypeId } from '@/lib/itemTypes';
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+
+type CreateGroupRequestBody = {
+  name?: unknown;
+  description?: unknown;
+  movieIds?: unknown;
+};
+
+const parseMovieIds = (value: unknown): number[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const uniqueIds = new Set<number>();
+
+  for (const entry of value) {
+    let normalized: number | null = null;
+
+    if (typeof entry === 'number' && Number.isFinite(entry)) {
+      normalized = Math.trunc(entry);
+    } else if (typeof entry === 'string' && entry.trim() !== '') {
+      const parsed = Number.parseInt(entry, 10);
+      if (Number.isFinite(parsed)) {
+        normalized = parsed;
+      }
+    }
+
+    if (normalized && normalized > 0) {
+      uniqueIds.add(normalized);
+    }
+  }
+
+  return Array.from(uniqueIds);
+};
+
+const extractBody = (payload: unknown): { name: string; description: string | null; movieIds: number[] } | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const { name, description, movieIds } = payload as CreateGroupRequestBody;
+
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return null;
+  }
+
+  const normalizedDescription =
+    typeof description === 'string' && description.trim().length > 0 ? description.trim() : null;
+
+  const normalizedMovieIds = parseMovieIds(movieIds);
+
+  return {
+    name: name.trim(),
+    description: normalizedDescription,
+    movieIds: normalizedMovieIds,
+  };
+};
+
+export async function POST(request: Request) {
+  const authorization = request.headers.get('authorization') ?? request.headers.get('Authorization');
+
+  if (!authorization || !authorization.toLowerCase().startsWith('bearer ')) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  const token = authorization.slice('bearer '.length).trim();
+
+  if (!token) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON.' }, { status: 400 });
+  }
+
+  const body = extractBody(payload);
+
+  if (!body) {
+    return NextResponse.json(
+      { error: 'Provide a group name, optional description, and at least two movie IDs.' },
+      { status: 400 }
+    );
+  }
+
+  if (body.movieIds.length < 2) {
+    return NextResponse.json(
+      { error: 'Select at least two movies to build a ranking group.' },
+      { status: 400 }
+    );
+  }
+
+  const { data: userResult, error: userError } = await supabaseAdminClient.auth.getUser(token);
+
+  if (userError || !userResult?.user) {
+    return NextResponse.json({ error: 'User session could not be verified.' }, { status: 401 });
+  }
+
+  const userId = userResult.user.id;
+
+  try {
+    const movieItemTypeId = await getMovieItemTypeId();
+
+    const { data: validMovies, error: validationError } = await supabaseAdminClient
+      .from('rankable_items')
+      .select('id')
+      .eq('item_type_id', movieItemTypeId)
+      .in('id', body.movieIds);
+
+    if (validationError) {
+      throw validationError;
+    }
+
+    if (!validMovies || validMovies.length !== body.movieIds.length) {
+      return NextResponse.json(
+        { error: 'One or more selected movies could not be found.' },
+        { status: 400 }
+      );
+    }
+
+    const { data: insertedGroup, error: insertError } = await supabaseAdminClient
+      .from('ranking_groups')
+      .insert({
+        name: body.name,
+        description: body.description,
+        creator_id: userId,
+        item_type_id: movieItemTypeId,
+      })
+      .select('id')
+      .single();
+
+    if (insertError || !insertedGroup) {
+      throw insertError ?? new Error('Group insert failed without an error message.');
+    }
+
+    const groupId = insertedGroup.id as string;
+
+    const groupItemsPayload = body.movieIds.map((itemId) => ({
+      group_id: groupId,
+      item_id: itemId,
+    }));
+
+    const { error: groupItemsError } = await supabaseAdminClient
+      .from('group_items')
+      .insert(groupItemsPayload);
+
+    if (groupItemsError) {
+      await supabaseAdminClient.from('ranking_groups').delete().eq('id', groupId);
+      throw groupItemsError;
+    }
+
+    const { error: participantError } = await supabaseAdminClient
+      .from('group_participants')
+      .upsert(
+        { group_id: groupId, user_id: userId },
+        { onConflict: 'user_id,group_id' }
+      );
+
+    if (participantError) {
+      await supabaseAdminClient.from('group_items').delete().eq('group_id', groupId);
+      await supabaseAdminClient.from('ranking_groups').delete().eq('id', groupId);
+      throw participantError;
+    }
+
+    return NextResponse.json({ groupId, movieCount: body.movieIds.length }, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create ranking group:', error);
+    return NextResponse.json({ error: 'Failed to create ranking group.' }, { status: 500 });
+  }
+}

--- a/app/components/MoviePoster.tsx
+++ b/app/components/MoviePoster.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Image from 'next/image';
+import type { ComponentPropsWithoutRef } from 'react';
+
+type MoviePosterProps = {
+  posterUrl: string | null;
+  title: string;
+  imageClassName?: string;
+  placeholderClassName?: string;
+  sizes?: ComponentPropsWithoutRef<typeof Image>['sizes'];
+};
+
+const DEFAULT_IMAGE_CLASS =
+  'h-auto w-48 rounded-md object-cover shadow-md shadow-black/50 sm:w-60';
+const DEFAULT_PLACEHOLDER_CLASS =
+  'flex h-72 w-48 items-center justify-center rounded-md bg-gray-800 text-sm text-gray-400 sm:w-60';
+const DEFAULT_SIZES = '(max-width: 640px) 12rem, (max-width: 1024px) 15rem, 20rem';
+
+const MoviePoster = ({
+  posterUrl,
+  title,
+  imageClassName = DEFAULT_IMAGE_CLASS,
+  placeholderClassName = DEFAULT_PLACEHOLDER_CLASS,
+  sizes = DEFAULT_SIZES,
+}: MoviePosterProps) => {
+  if (!posterUrl) {
+    return <div className={placeholderClassName}>Poster unavailable</div>;
+  }
+
+  return (
+    <Image
+      src={posterUrl}
+      alt={`${title} poster`}
+      width={342}
+      height={513}
+      className={imageClassName}
+      sizes={sizes}
+    />
+  );
+};
+
+export default MoviePoster;

--- a/app/groups/new/CreateMovieGroupForm.tsx
+++ b/app/groups/new/CreateMovieGroupForm.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import MoviePoster from '@/app/components/MoviePoster';
+import { supabase } from '@/lib/supabaseClient';
+
+type MovieOption = {
+  id: number;
+  name: string;
+  posterUrl: string | null;
+  releaseYear: string | null;
+};
+
+type CreateMovieGroupFormProps = {
+  movies: MovieOption[];
+};
+
+type CreateGroupResponse = {
+  groupId?: string;
+  movieCount?: number;
+  error?: string;
+};
+
+const MIN_MOVIE_SELECTION = 2;
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+const CreateMovieGroupForm = ({ movies }: CreateMovieGroupFormProps) => {
+  const [groupName, setGroupName] = useState('');
+  const [groupDescription, setGroupDescription] = useState('');
+  const [selectedMovies, setSelectedMovies] = useState<Set<number>>(new Set());
+  const [searchTerm, setSearchTerm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const syncSession = async () => {
+      const { data } = await supabase.auth.getSession();
+
+      if (!isMounted) {
+        return;
+      }
+
+      const token = data.session?.access_token ?? null;
+      setAccessToken(token);
+    };
+
+    syncSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setAccessToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const toggleMovieSelection = (movieId: number) => {
+    setSelectedMovies((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(movieId)) {
+        next.delete(movieId);
+      } else {
+        next.add(movieId);
+      }
+
+      return next;
+    });
+  };
+
+  const filteredMovies = useMemo(() => {
+    const normalizedSearch = normalizeSearch(searchTerm);
+
+    if (!normalizedSearch) {
+      return movies;
+    }
+
+    return movies.filter((movie) => normalizeSearch(movie.name).includes(normalizedSearch));
+  }, [movies, searchTerm]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    setError(null);
+    setSuccessMessage(null);
+
+    if (!accessToken) {
+      setError('You must be signed in to create a ranking group.');
+      return;
+    }
+
+    if (!groupName.trim()) {
+      setError('Enter a name for your ranking group.');
+      return;
+    }
+
+    if (selectedMovies.size < MIN_MOVIE_SELECTION) {
+      setError(`Choose at least ${MIN_MOVIE_SELECTION} movies to get started.`);
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      const response = await fetch('/api/groups', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          name: groupName.trim(),
+          description: groupDescription.trim() || null,
+          movieIds: Array.from(selectedMovies),
+        }),
+      });
+
+      const payload = (await response.json()) as CreateGroupResponse;
+
+      if (!response.ok) {
+        setError(payload.error ?? 'Failed to create ranking group.');
+        return;
+      }
+
+      const createdMovieCount = payload.movieCount ?? selectedMovies.size;
+
+      setSuccessMessage(
+        `Group created successfully with ${createdMovieCount} movie${createdMovieCount === 1 ? '' : 's'}. Save the ID ` +
+          `(${payload.groupId}) to reference it later.`
+      );
+      setGroupName('');
+      setGroupDescription('');
+      setSelectedMovies(new Set());
+      setSearchTerm('');
+    } catch (submissionError) {
+      const message =
+        submissionError instanceof Error ? submissionError.message : 'Unexpected error while creating the group.';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const selectedCount = selectedMovies.size;
+  const isAuthenticated = Boolean(accessToken);
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-10 flex flex-col gap-10">
+      <section className="rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30">
+        <h2 className="text-2xl font-semibold text-white">Group details</h2>
+        <p className="mt-2 text-sm text-gray-300">
+          Give your group a descriptive name and optional summary to help participants understand what you&apos;re ranking.
+        </p>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          <div className="space-y-2">
+            <label htmlFor="group-name" className="text-sm font-medium text-gray-200">
+              Group name
+            </label>
+            <input
+              id="group-name"
+              type="text"
+              value={groupName}
+              onChange={(event) => setGroupName(event.target.value)}
+              placeholder="90s Sci-Fi Classics"
+              className="w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div className="space-y-2 lg:col-span-1">
+            <label htmlFor="group-description" className="text-sm font-medium text-gray-200">
+              Description <span className="text-gray-500">(optional)</span>
+            </label>
+            <textarea
+              id="group-description"
+              value={groupDescription}
+              onChange={(event) => setGroupDescription(event.target.value)}
+              placeholder="Rank the science fiction movies from the 1990s that defined the genre for you."
+              rows={4}
+              className="w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">Pick the movies to rank</h2>
+            <p className="mt-2 text-sm text-gray-300">
+              Tap a movie to toggle it in your group. You need at least {MIN_MOVIE_SELECTION} movies to begin ranking.
+            </p>
+            {!isAuthenticated && (
+              <p className="mt-2 text-sm text-amber-300">
+                You&apos;ll need to sign in before you can create a group.
+              </p>
+            )}
+          </div>
+          {movies.length > 0 && (
+            <div className="w-full sm:w-64">
+              <label htmlFor="movie-search" className="block text-sm font-medium text-gray-200">
+                Search movies
+              </label>
+              <input
+                id="movie-search"
+                type="search"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search by title"
+                className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+          )}
+        </div>
+
+        <p className="mt-6 text-sm text-gray-300">
+          Selected movies: <span className="font-semibold text-white">{selectedCount}</span>
+        </p>
+
+        {movies.length === 0 ? (
+          <p className="mt-6 text-sm text-gray-300">
+            Upload some movies first to build your library. Once they&apos;re available, you can add them to ranking groups here.
+          </p>
+        ) : filteredMovies.length === 0 ? (
+          <p className="mt-6 text-sm text-gray-300">No movies match your search. Try a different title.</p>
+        ) : (
+          <ul className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredMovies.map((movie) => {
+              const isSelected = selectedMovies.has(movie.id);
+
+              return (
+                <li key={movie.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggleMovieSelection(movie.id)}
+                    className={`relative flex h-full w-full flex-col rounded-lg border bg-gray-950/80 p-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+                      isSelected
+                        ? 'border-blue-400/80 shadow-lg shadow-blue-500/30'
+                        : 'border-gray-800 shadow-lg shadow-black/30 hover:border-blue-500/40'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <div className="flex justify-center">
+                      <MoviePoster
+                        posterUrl={movie.posterUrl}
+                        title={movie.name}
+                        imageClassName="h-auto w-40 rounded-md object-cover shadow-md shadow-black/40 sm:w-48"
+                        placeholderClassName="flex h-60 w-40 items-center justify-center rounded-md bg-gray-800 text-sm text-gray-400 sm:w-48"
+                        sizes="(max-width: 640px) 10rem, (max-width: 1024px) 12rem, 16rem"
+                      />
+                    </div>
+                    <div className="mt-4 flex flex-col gap-2">
+                      <p className="text-lg font-semibold text-white">{movie.name}</p>
+                      <p className="text-sm text-gray-400">
+                        {movie.releaseYear ? `Released ${movie.releaseYear}` : 'Release year unknown'}
+                      </p>
+                    </div>
+                    {isSelected && (
+                      <span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-blue-500/90 px-3 py-1 text-xs font-semibold text-white">
+                        Selected
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {error && (
+        <div className="rounded-md border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200 shadow">
+          {error}
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="rounded-md border border-green-500/60 bg-green-500/10 px-4 py-3 text-sm text-green-200 shadow">
+          {successMessage}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-4">
+        <button
+          type="submit"
+          disabled={submitting || !isAuthenticated || movies.length === 0}
+          className="inline-flex items-center rounded-md bg-blue-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting ? 'Creating group…' : 'Create ranking group'}
+        </button>
+        {!isAuthenticated && (
+          <p className="text-sm text-gray-300">
+            Sign in from the homepage to unlock group creation.
+          </p>
+        )}
+      </div>
+    </form>
+  );
+};
+
+export default CreateMovieGroupForm;

--- a/app/groups/new/page.tsx
+++ b/app/groups/new/page.tsx
@@ -1,0 +1,33 @@
+import CreateMovieGroupForm from './CreateMovieGroupForm';
+
+import { MOVIE_POSTER_SIZE, fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
+import { buildPosterUrl, getTmdbConfiguration } from '@/lib/tmdb';
+
+export const revalidate = 0;
+
+export default async function CreateGroupPage() {
+  const [movies, tmdbConfig] = await Promise.all([fetchMovieRecords(), getTmdbConfiguration()]);
+
+  const movieOptions = movies.map((movie) => ({
+    id: movie.id,
+    name: movie.name,
+    posterUrl: buildPosterUrl(tmdbConfig, movie.image_path, MOVIE_POSTER_SIZE),
+    releaseYear: parseMovieReleaseYear(movie.metadata ?? null),
+  }));
+
+  return (
+    <main className="min-h-screen bg-gray-900 px-6 py-12 text-white">
+      <div className="mx-auto w-full max-w-6xl">
+        <header className="flex flex-col gap-4 text-center sm:text-left">
+          <h1 className="text-4xl font-bold sm:text-5xl">Create a movie ranking group</h1>
+          <p className="text-lg text-gray-300">
+            Curate a collection of uploaded movies and invite friends to rank them head-to-head. You can come back later to add
+            more films as your library grows.
+          </p>
+        </header>
+
+        <CreateMovieGroupForm movies={movieOptions} />
+      </div>
+    </main>
+  );
+}

--- a/lib/movies.ts
+++ b/lib/movies.ts
@@ -1,0 +1,48 @@
+import { supabaseAdminClient } from './supabaseAdminClient';
+import { getMovieItemTypeId } from './itemTypes';
+
+export const MOVIE_POSTER_SIZE = 'w342';
+
+export type MovieRecord = {
+  id: number;
+  name: string;
+  image_path: string | null;
+  metadata: Record<string, unknown> | null;
+};
+
+export const parseMovieReleaseYear = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const typedMetadata = metadata as {
+    tmdb?: { release_date?: string | null };
+    release_date?: string | null;
+    releaseDate?: string | null;
+  };
+
+  const releaseDate =
+    typedMetadata.tmdb?.release_date ?? typedMetadata.release_date ?? typedMetadata.releaseDate;
+
+  if (typeof releaseDate !== 'string' || releaseDate.length < 4) {
+    return null;
+  }
+
+  return releaseDate.slice(0, 4);
+};
+
+export const fetchMovieRecords = async (): Promise<MovieRecord[]> => {
+  const movieItemTypeId = await getMovieItemTypeId();
+
+  const { data, error } = await supabaseAdminClient
+    .from('rankable_items')
+    .select('id, name, image_path, metadata')
+    .eq('item_type_id', movieItemTypeId)
+    .order('name', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as MovieRecord[];
+};


### PR DESCRIPTION
## Summary
- extract shared movie fetching helpers and poster component so the new UI can reuse existing artwork rendering
- add a /groups/new page with an authenticated form to search, select, and submit movies for a ranking group
- create an API endpoint that verifies the user, creates the ranking group, and links the chosen movies and creator participation

## Testing
- npm run build *(fails: Next.js cannot download the Geist fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1675bb338832e85b9d9e1454bfeb5