### PR TITLE
Add movie comparison UI and Elo rating updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ application:
 Each upload returns a summary of movies that were added, skipped (missing data, no TMDb match, or duplicates), and any
 errors encountered while contacting TMDb or Supabase.
 
+## Head-to-head rankings
+
+1. Create a ranking group from `/groups/new` and note the group ID that is returned.
+2. Apply the migration at `supabase/migrations/20250211000001_create_movie_comparison_function.sql` to your database so
+   match results can be processed.
+3. Visit `/groups/<group-id>` (for example, `/groups/123e4567-e89b-12d3-a456-426614174000`) to load the new comparison
+   interface.
+4. Sign in and repeatedly pick your preferred movie in each matchup. The backend updates Elo ratings after every choice.
+
 ## Running the project
 
 Start the local development server:

--- a/app/api/groups/[groupId]/match/route.ts
+++ b/app/api/groups/[groupId]/match/route.ts
@@ -1,0 +1,467 @@
+import { NextResponse } from 'next/server';
+
+import { getMovieItemTypeId } from '@/lib/itemTypes';
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+
+const DEFAULT_RATING = 1200;
+const MIN_NEW_ITEM_COMPARISONS = 5;
+const DISCOVERY_MATCH_PROBABILITY = 0.15;
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const extractBearerToken = (request: Request): string | null => {
+  const authorizationHeader = request.headers.get('authorization') ?? request.headers.get('Authorization');
+
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const normalizedHeader = authorizationHeader.trim();
+
+  if (!normalizedHeader.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  const token = normalizedHeader.slice('bearer '.length).trim();
+
+  return token.length > 0 ? token : null;
+};
+
+const isValidUuid = (value: string) => UUID_REGEX.test(value);
+
+type SupabaseGroupItem = {
+  item_id: number;
+  rankable_items: {
+    id: number;
+    name: string;
+    image_path: string | null;
+    metadata: Record<string, unknown> | null;
+  } | null;
+};
+
+type SupabaseRatingRow = {
+  item_id: number;
+  rating: string | number;
+  comparison_count: number;
+};
+
+type MatchItem = {
+  itemId: number;
+  name: string;
+  imagePath: string | null;
+  metadata: Record<string, unknown> | null;
+  rating: number;
+  comparisonCount: number;
+};
+
+const normalizeRating = (value: string | number | null | undefined): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return DEFAULT_RATING;
+};
+
+const randomIndex = (length: number) => Math.floor(Math.random() * length);
+
+const selectRandomPair = (items: MatchItem[]): [MatchItem, MatchItem] => {
+  const pool = [...items];
+  const firstIndex = randomIndex(pool.length);
+  const [first] = pool.splice(firstIndex, 1);
+  const secondIndex = randomIndex(pool.length);
+  const [second] = pool.splice(secondIndex, 1);
+
+  return [first, second];
+};
+
+const selectAdjacentByRating = (items: MatchItem[]): [MatchItem, MatchItem] => {
+  if (items.length <= 2) {
+    return [items[0], items[1]];
+  }
+
+  const sorted = [...items].sort((a, b) => a.rating - b.rating);
+  let bestPair: [MatchItem, MatchItem] = [sorted[0], sorted[1]];
+  let smallestDiff = Math.abs(sorted[1].rating - sorted[0].rating);
+
+  for (let index = 1; index < sorted.length - 1; index += 1) {
+    const current = sorted[index];
+    const next = sorted[index + 1];
+    const diff = Math.abs(next.rating - current.rating);
+
+    if (diff < smallestDiff) {
+      smallestDiff = diff;
+      bestPair = [current, next];
+    }
+  }
+
+  return bestPair;
+};
+
+const selectDiscoveryPair = (items: MatchItem[]): [MatchItem, MatchItem] => {
+  if (items.length <= 2) {
+    return [items[0], items[1]];
+  }
+
+  const sorted = [...items].sort((a, b) => a.rating - b.rating);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+
+  return [first, last];
+};
+
+const chooseMatchup = (items: MatchItem[]): [MatchItem, MatchItem] | null => {
+  if (items.length < 2) {
+    return null;
+  }
+
+  const lowHistoryItems = items.filter((item) => item.comparisonCount < MIN_NEW_ITEM_COMPARISONS);
+
+  if (lowHistoryItems.length >= 2) {
+    return selectRandomPair(lowHistoryItems);
+  }
+
+  const shouldExplore = Math.random() < DISCOVERY_MATCH_PROBABILITY;
+
+  if (shouldExplore) {
+    return selectDiscoveryPair(items);
+  }
+
+  return selectAdjacentByRating(items);
+};
+
+const shuffleOrientation = (pair: [MatchItem, MatchItem]): [MatchItem, MatchItem] => {
+  return Math.random() < 0.5 ? pair : [pair[1], pair[0]];
+};
+
+const buildMatchItems = (
+  groupItems: SupabaseGroupItem[],
+  ratingRows: SupabaseRatingRow[]
+): MatchItem[] => {
+  const ratingMap = new Map<number, SupabaseRatingRow>();
+
+  for (const row of ratingRows) {
+    ratingMap.set(row.item_id, row);
+  }
+
+  const items: MatchItem[] = [];
+
+  for (const groupItem of groupItems) {
+    if (!groupItem.rankable_items) {
+      continue;
+    }
+
+    const ratingRow = ratingMap.get(groupItem.item_id);
+
+    items.push({
+      itemId: groupItem.rankable_items.id,
+      name: groupItem.rankable_items.name,
+      imagePath: groupItem.rankable_items.image_path,
+      metadata: groupItem.rankable_items.metadata,
+      rating: normalizeRating(ratingRow?.rating),
+      comparisonCount: ratingRow?.comparison_count ?? 0,
+    });
+  }
+
+  return items;
+};
+
+export async function GET(
+  request: Request,
+  context: { params: { groupId: string } }
+): Promise<NextResponse> {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  const { groupId } = context.params;
+
+  if (!groupId || !isValidUuid(groupId)) {
+    return NextResponse.json({ error: 'Provide a valid group identifier.' }, { status: 400 });
+  }
+
+  const { data: userResult, error: userError } = await supabaseAdminClient.auth.getUser(token);
+
+  if (userError || !userResult?.user) {
+    return NextResponse.json({ error: 'User session could not be verified.' }, { status: 401 });
+  }
+
+  try {
+    const userId = userResult.user.id;
+
+    const { data: group, error: groupError } = await supabaseAdminClient
+      .from('ranking_groups')
+      .select('id, item_type_id')
+      .eq('id', groupId)
+      .maybeSingle();
+
+    if (groupError) {
+      throw groupError;
+    }
+
+    if (!group) {
+      return NextResponse.json({ error: 'Group not found.' }, { status: 404 });
+    }
+
+    const movieItemTypeId = await getMovieItemTypeId();
+
+    if (group.item_type_id !== movieItemTypeId) {
+      return NextResponse.json({ error: 'Only movie groups support matchups right now.' }, { status: 400 });
+    }
+
+    const { error: participantError } = await supabaseAdminClient
+      .from('group_participants')
+      .upsert(
+        { group_id: groupId, user_id: userId },
+        { onConflict: 'user_id,group_id' }
+      );
+
+    if (participantError) {
+      throw participantError;
+    }
+
+    const { data: groupItems, error: groupItemsError } = await supabaseAdminClient
+      .from('group_items')
+      .select('item_id, rankable_items!inner(id, name, image_path, metadata)')
+      .eq('group_id', groupId);
+
+    if (groupItemsError) {
+      throw groupItemsError;
+    }
+
+    if (!groupItems || groupItems.length < 2) {
+      return NextResponse.json(
+        { error: 'At least two movies are required to start ranking this group.' },
+        { status: 400 }
+      );
+    }
+
+    const { data: ratingRows, error: ratingsError } = await supabaseAdminClient
+      .from('user_group_item_ratings')
+      .select('item_id, rating, comparison_count')
+      .eq('group_id', groupId)
+      .eq('user_id', userId);
+
+    if (ratingsError) {
+      throw ratingsError;
+    }
+
+    const items = buildMatchItems(groupItems as SupabaseGroupItem[], (ratingRows ?? []) as SupabaseRatingRow[]);
+    const matchup = chooseMatchup(items);
+
+    if (!matchup) {
+      return NextResponse.json(
+        { error: 'At least two movies are required to start ranking this group.' },
+        { status: 400 }
+      );
+    }
+
+    const [first, second] = shuffleOrientation(matchup);
+
+    return NextResponse.json({
+      matchup: [
+        {
+          itemId: first.itemId,
+          name: first.name,
+          imagePath: first.imagePath,
+          metadata: first.metadata,
+          rating: first.rating,
+          comparisonCount: first.comparisonCount,
+        },
+        {
+          itemId: second.itemId,
+          name: second.name,
+          imagePath: second.imagePath,
+          metadata: second.metadata,
+          rating: second.rating,
+          comparisonCount: second.comparisonCount,
+        },
+      ],
+    });
+  } catch (error) {
+    console.error('Failed to build matchup for group:', error);
+    return NextResponse.json({ error: 'Failed to generate the next matchup.' }, { status: 500 });
+  }
+}
+
+type ComparisonRequestBody = {
+  winnerItemId?: unknown;
+  loserItemId?: unknown;
+};
+
+const parseComparisonBody = (
+  payload: ComparisonRequestBody
+): { winnerItemId: number; loserItemId: number } | null => {
+  const { winnerItemId, loserItemId } = payload;
+
+  const parseId = (value: unknown): number | null => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.trunc(value);
+    }
+
+    if (typeof value === 'string' && value.trim() !== '') {
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    return null;
+  };
+
+  const winner = parseId(winnerItemId);
+  const loser = parseId(loserItemId);
+
+  if (!winner || !loser || winner === loser) {
+    return null;
+  }
+
+  return { winnerItemId: winner, loserItemId: loser };
+};
+
+type ComparisonResultRow = {
+  winner_item_id: number;
+  winner_rating: string | number;
+  winner_comparison_count: number;
+  loser_item_id: number;
+  loser_rating: string | number;
+  loser_comparison_count: number;
+};
+
+const normalizeComparisonResult = (row: ComparisonResultRow | undefined | null) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    winner: {
+      itemId: row.winner_item_id,
+      rating: normalizeRating(row.winner_rating),
+      comparisonCount: row.winner_comparison_count,
+    },
+    loser: {
+      itemId: row.loser_item_id,
+      rating: normalizeRating(row.loser_rating),
+      comparisonCount: row.loser_comparison_count,
+    },
+  } as const;
+};
+
+export async function POST(
+  request: Request,
+  context: { params: { groupId: string } }
+): Promise<NextResponse> {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  const { groupId } = context.params;
+
+  if (!groupId || !isValidUuid(groupId)) {
+    return NextResponse.json({ error: 'Provide a valid group identifier.' }, { status: 400 });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be valid JSON.' }, { status: 400 });
+  }
+
+  const parsedPayload = parseComparisonBody((payload ?? {}) as ComparisonRequestBody);
+
+  if (!parsedPayload) {
+    return NextResponse.json({ error: 'Provide winner and loser movie IDs.' }, { status: 400 });
+  }
+
+  const { data: userResult, error: userError } = await supabaseAdminClient.auth.getUser(token);
+
+  if (userError || !userResult?.user) {
+    return NextResponse.json({ error: 'User session could not be verified.' }, { status: 401 });
+  }
+
+  try {
+    const userId = userResult.user.id;
+
+    const { data: group, error: groupError } = await supabaseAdminClient
+      .from('ranking_groups')
+      .select('id, item_type_id')
+      .eq('id', groupId)
+      .maybeSingle();
+
+    if (groupError) {
+      throw groupError;
+    }
+
+    if (!group) {
+      return NextResponse.json({ error: 'Group not found.' }, { status: 404 });
+    }
+
+    const movieItemTypeId = await getMovieItemTypeId();
+
+    if (group.item_type_id !== movieItemTypeId) {
+      return NextResponse.json({ error: 'Only movie groups support matchups right now.' }, { status: 400 });
+    }
+
+    const { error: participantError } = await supabaseAdminClient
+      .from('group_participants')
+      .upsert(
+        { group_id: groupId, user_id: userId },
+        { onConflict: 'user_id,group_id' }
+      );
+
+    if (participantError) {
+      throw participantError;
+    }
+
+    const { data: groupItems, error: groupItemsError } = await supabaseAdminClient
+      .from('group_items')
+      .select('item_id')
+      .eq('group_id', groupId)
+      .in('item_id', [parsedPayload.winnerItemId, parsedPayload.loserItemId]);
+
+    if (groupItemsError) {
+      throw groupItemsError;
+    }
+
+    if (!groupItems || groupItems.length !== 2) {
+      return NextResponse.json({ error: 'Both movies must belong to this group.' }, { status: 400 });
+    }
+
+    const { data: comparisonResult, error: comparisonError } = await supabaseAdminClient.rpc(
+      'process_group_movie_comparison',
+      {
+        p_user_id: userId,
+        p_group_id: groupId,
+        p_winner_item_id: parsedPayload.winnerItemId,
+        p_loser_item_id: parsedPayload.loserItemId,
+      }
+    );
+
+    if (comparisonError) {
+      throw comparisonError;
+    }
+
+    const normalizedResult = normalizeComparisonResult((comparisonResult ?? [])[0] as ComparisonResultRow | undefined);
+
+    if (!normalizedResult) {
+      return NextResponse.json({ error: 'Failed to update movie ratings.' }, { status: 500 });
+    }
+
+    return NextResponse.json(normalizedResult);
+  } catch (error) {
+    console.error('Failed to process comparison result:', error);
+    return NextResponse.json({ error: 'Failed to process the comparison result.' }, { status: 500 });
+  }
+}

--- a/app/groups/[groupId]/MovieComparisonArena.tsx
+++ b/app/groups/[groupId]/MovieComparisonArena.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import MoviePoster from '@/app/components/MoviePoster';
+import { parseMovieReleaseYear, MOVIE_POSTER_SIZE } from '@/lib/movieMetadata';
+import { supabase } from '@/lib/supabaseClient';
+import { buildPosterUrl, type TmdbConfigurationResponse } from '@/lib/tmdb';
+
+type MatchItem = {
+  itemId: number;
+  name: string;
+  imagePath: string | null;
+  metadata: Record<string, unknown> | null;
+  rating: number;
+  comparisonCount: number;
+};
+
+type MatchupResponse = {
+  matchup?: MatchItem[];
+  error?: string;
+};
+
+type ComparisonResultResponse = {
+  winner?: {
+    itemId: number;
+    rating: number;
+    comparisonCount: number;
+  };
+  loser?: {
+    itemId: number;
+    rating: number;
+    comparisonCount: number;
+  };
+  error?: string;
+};
+
+type MatchupMovie = MatchItem & {
+  posterUrl: string | null;
+  releaseYear: string | null;
+};
+
+type ResultSummary = {
+  winner: {
+    name: string;
+    ratingBefore: number;
+    ratingAfter: number;
+    comparisonsAfter: number;
+  };
+  loser: {
+    name: string;
+    ratingBefore: number;
+    ratingAfter: number;
+    comparisonsAfter: number;
+  };
+};
+
+type MovieComparisonArenaProps = {
+  groupId: string;
+  groupName: string;
+  movieCount: number;
+  tmdbConfig: TmdbConfigurationResponse;
+};
+
+const formatRating = (value: number) => value.toFixed(1);
+
+const formatDelta = (value: number) => {
+  const rounded = value.toFixed(1);
+  return value >= 0 ? `+${rounded}` : rounded;
+};
+
+const MovieComparisonArena = ({ groupId, groupName, movieCount, tmdbConfig }: MovieComparisonArenaProps) => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [loadingMatchup, setLoadingMatchup] = useState(false);
+  const [matchup, setMatchup] = useState<MatchItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [resultSummary, setResultSummary] = useState<ResultSummary | null>(null);
+
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const syncSession = async () => {
+      const { data } = await supabase.auth.getSession();
+
+      if (!active || !isMountedRef.current) {
+        return;
+      }
+
+      setAccessToken(data.session?.access_token ?? null);
+    };
+
+    syncSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setAccessToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      active = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!accessToken) {
+      setResultSummary(null);
+      setError(null);
+    }
+  }, [accessToken]);
+
+  const fetchNextMatchup = useCallback(
+    async (token: string) => {
+      setLoadingMatchup(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/groups/${groupId}/match`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          cache: 'no-store',
+        });
+
+        const payload = (await response.json()) as MatchupResponse;
+
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        if (!response.ok) {
+          setMatchup(null);
+          setError(payload.error ?? 'Failed to load the next matchup.');
+          return;
+        }
+
+        const movies = payload.matchup ?? [];
+
+        if (movies.length !== 2) {
+          setMatchup(null);
+          setError('Not enough movies are available to create a matchup.');
+          return;
+        }
+
+        setMatchup(movies);
+      } catch (requestError) {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        const message =
+          requestError instanceof Error ? requestError.message : 'Unexpected error while loading the matchup.';
+        setError(message);
+        setMatchup(null);
+      } finally {
+        if (isMountedRef.current) {
+          setLoadingMatchup(false);
+        }
+      }
+    },
+    [groupId]
+  );
+
+  useEffect(() => {
+    if (!accessToken || movieCount < 2) {
+      setMatchup(null);
+      return;
+    }
+
+    fetchNextMatchup(accessToken);
+  }, [accessToken, fetchNextMatchup, movieCount]);
+
+  const derivedMatchup = useMemo<MatchupMovie[] | null>(() => {
+    if (!matchup) {
+      return null;
+    }
+
+    return matchup.map((movie) => ({
+      ...movie,
+      posterUrl: buildPosterUrl(tmdbConfig, movie.imagePath, MOVIE_POSTER_SIZE),
+      releaseYear: parseMovieReleaseYear(movie.metadata),
+    }));
+  }, [matchup, tmdbConfig]);
+
+  const handleVote = async (winner: MatchItem, loser: MatchItem) => {
+    if (!accessToken || submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/groups/${groupId}/match`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ winnerItemId: winner.itemId, loserItemId: loser.itemId }),
+      });
+
+      const payload = (await response.json()) as ComparisonResultResponse;
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (!response.ok || !payload.winner || !payload.loser) {
+        setError(payload.error ?? 'Failed to record your comparison.');
+        return;
+      }
+
+      setResultSummary({
+        winner: {
+          name: winner.name,
+          ratingBefore: winner.rating,
+          ratingAfter: payload.winner.rating,
+          comparisonsAfter: payload.winner.comparisonCount,
+        },
+        loser: {
+          name: loser.name,
+          ratingBefore: loser.rating,
+          ratingAfter: payload.loser.rating,
+          comparisonsAfter: payload.loser.comparisonCount,
+        },
+      });
+
+      await fetchNextMatchup(accessToken);
+    } catch (submissionError) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const message =
+        submissionError instanceof Error
+          ? submissionError.message
+          : 'Unexpected error while submitting the comparison.';
+      setError(message);
+    } finally {
+      if (isMountedRef.current) {
+        setSubmitting(false);
+      }
+    }
+  };
+
+  const isAuthenticated = Boolean(accessToken);
+  const showMatchup = Boolean(derivedMatchup) && !loadingMatchup && !error;
+
+  return (
+    <section className="mb-16 rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2 text-center sm:text-left">
+          <h2 className="text-2xl font-semibold text-white">Rank movies in {groupName}</h2>
+          <p className="text-sm text-gray-300">
+            Choose the movie that you prefer in each matchup to update your Elo ratings. Ratings start at 1200 and stabilize as
+            you make more comparisons.
+          </p>
+        </div>
+
+        {!isAuthenticated ? (
+          <div className="rounded-md border border-amber-500/60 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+            Sign in from the homepage to begin ranking these movies. Your comparisons will be saved to your account.
+          </div>
+        ) : null}
+
+        {movieCount < 2 ? (
+          <div className="rounded-md border border-blue-500/60 bg-blue-500/10 px-4 py-3 text-sm text-blue-200">
+            Add at least two movies to this group to start ranking. You currently have {movieCount}{' '}
+            {movieCount === 1 ? 'movie' : 'movies'} configured.
+          </div>
+        ) : null}
+
+        {error ? (
+          <div className="rounded-md border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</div>
+        ) : null}
+
+        {resultSummary ? (
+          <div className="rounded-md border border-green-500/60 bg-green-500/10 px-4 py-3 text-sm text-green-200">
+            <p className="font-semibold">Comparison recorded!</p>
+            <p className="mt-1">
+              <span className="font-semibold text-white">{resultSummary.winner.name}</span> moved from{' '}
+              {formatRating(resultSummary.winner.ratingBefore)} to {formatRating(resultSummary.winner.ratingAfter)} (
+              {formatDelta(resultSummary.winner.ratingAfter - resultSummary.winner.ratingBefore)}). It has now appeared in{' '}
+              {resultSummary.winner.comparisonsAfter} comparisons.
+            </p>
+            <p className="mt-1">
+              <span className="font-semibold text-white">{resultSummary.loser.name}</span> shifted to{' '}
+              {formatRating(resultSummary.loser.ratingAfter)} ({formatDelta(
+                resultSummary.loser.ratingAfter - resultSummary.loser.ratingBefore
+              )}).
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-4">
+          {showMatchup ? (
+            <div className="grid gap-6 lg:grid-cols-2">
+              {derivedMatchup!.map((movie, index) => {
+                const opponent = derivedMatchup![index === 0 ? 1 : 0];
+
+                return (
+                  <button
+                    key={movie.itemId}
+                    type="button"
+                    onClick={() => handleVote(matchup![index], matchup![index === 0 ? 1 : 0])}
+                    disabled={!isAuthenticated || submitting || loadingMatchup}
+                    className="group flex h-full flex-col gap-4 rounded-lg border border-gray-800 bg-gray-900/80 p-4 text-left transition hover:border-blue-500/60 hover:shadow-lg hover:shadow-blue-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <div className="flex justify-center">
+                      <MoviePoster posterUrl={movie.posterUrl} title={movie.name} />
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <div>
+                        <p className="text-xl font-semibold text-white">{movie.name}</p>
+                        <p className="text-sm text-gray-400">
+                          {movie.releaseYear ? `Released ${movie.releaseYear}` : 'Release year unknown'}
+                        </p>
+                      </div>
+                      <div className="rounded-md bg-gray-950/80 px-3 py-2 text-sm text-gray-300">
+                        <p>
+                          Current rating: <span className="font-semibold text-white">{formatRating(movie.rating)}</span>
+                        </p>
+                        <p>
+                          Comparisons logged:{' '}
+                          <span className="font-semibold text-white">{movie.comparisonCount}</span>
+                        </p>
+                      </div>
+                      <p className="text-sm text-gray-300">
+                        Prefer <span className="font-semibold text-white">{movie.name}</span> over{' '}
+                        <span className="font-semibold text-white">{opponent.name}</span>
+                      </p>
+                      <span className="inline-flex items-center justify-center rounded-md bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition group-hover:bg-blue-400">
+                        Choose {movie.name}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex min-h-[18rem] items-center justify-center rounded-lg border border-dashed border-gray-800 bg-gray-900/40 p-8 text-center text-sm text-gray-300">
+              {loadingMatchup
+                ? 'Looking for your next matchup…'
+                : isAuthenticated
+                  ? 'Once a matchup is ready it will appear here. Add more movies if you run out of comparisons.'
+                  : 'Sign in to start ranking these movies.'}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MovieComparisonArena;

--- a/app/groups/[groupId]/page.tsx
+++ b/app/groups/[groupId]/page.tsx
@@ -1,0 +1,104 @@
+import { notFound } from 'next/navigation';
+
+import MovieComparisonArena from './MovieComparisonArena';
+
+import { getMovieItemTypeId } from '@/lib/itemTypes';
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+import { getTmdbConfiguration } from '@/lib/tmdb';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const revalidate = 0;
+
+const isValidUuid = (value: string) => UUID_REGEX.test(value);
+
+type GroupPageProps = {
+  params: { groupId: string };
+};
+
+type GroupRecord = {
+  id: string;
+  name: string;
+  description: string | null;
+  item_type_id: number;
+};
+
+const fetchGroupRecord = async (groupId: string): Promise<GroupRecord> => {
+  const { data, error } = await supabaseAdminClient
+    .from('ranking_groups')
+    .select('id, name, description, item_type_id')
+    .eq('id', groupId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    notFound();
+  }
+
+  return data as GroupRecord;
+};
+
+const fetchGroupItemCount = async (groupId: string): Promise<number> => {
+  const { count, error } = await supabaseAdminClient
+    .from('group_items')
+    .select('item_id', { count: 'exact', head: true })
+    .eq('group_id', groupId);
+
+  if (error) {
+    throw error;
+  }
+
+  return count ?? 0;
+};
+
+export default async function GroupComparisonPage({ params }: GroupPageProps) {
+  const { groupId } = params;
+
+  if (!groupId || !isValidUuid(groupId)) {
+    notFound();
+  }
+
+  const [movieItemTypeId, groupRecord] = await Promise.all([
+    getMovieItemTypeId(),
+    fetchGroupRecord(groupId),
+  ]);
+
+  if (groupRecord.item_type_id !== movieItemTypeId) {
+    notFound();
+  }
+
+  const [movieCount, tmdbConfig] = await Promise.all([
+    fetchGroupItemCount(groupId),
+    getTmdbConfiguration(),
+  ]);
+
+  return (
+    <main className="min-h-screen bg-gray-900 px-6 py-12 text-white">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
+        <header className="flex flex-col gap-4 text-center sm:text-left">
+          <div className="space-y-2">
+            <p className="text-sm uppercase tracking-wide text-blue-300">Movie Rankings</p>
+            <h1 className="text-4xl font-bold sm:text-5xl">{groupRecord.name}</h1>
+          </div>
+          {groupRecord.description ? (
+            <p className="text-lg text-gray-300">{groupRecord.description}</p>
+          ) : (
+            <p className="text-lg text-gray-300">
+              Pick the movie you prefer in each matchup to shape your personal Elo rankings for this group.
+            </p>
+          )}
+        </header>
+
+        <MovieComparisonArena
+          groupId={groupId}
+          groupName={groupRecord.name}
+          movieCount={movieCount}
+          tmdbConfig={tmdbConfig}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/groups/new/CreateMovieGroupForm.tsx
+++ b/app/groups/new/CreateMovieGroupForm.tsx
@@ -134,9 +134,17 @@ const CreateMovieGroupForm = ({ movies }: CreateMovieGroupFormProps) => {
 
       const createdMovieCount = payload.movieCount ?? selectedMovies.size;
 
+      const comparisonHint =
+        payload.groupId && payload.groupId.trim().length > 0
+          ? ` Visit the new ranking page at /groups/${payload.groupId} to start comparing.`
+          : '';
+
+      const displayGroupId = payload.groupId ?? 'unknown';
+
       setSuccessMessage(
         `Group created successfully with ${createdMovieCount} movie${createdMovieCount === 1 ? '' : 's'}. Save the ID ` +
-          `(${payload.groupId}) to reference it later.`
+          `(${displayGroupId}) to reference it later.` +
+          comparisonHint
       );
       setGroupName('');
       setGroupDescription('');

--- a/lib/movieMetadata.ts
+++ b/lib/movieMetadata.ts
@@ -1,0 +1,25 @@
+export const MOVIE_POSTER_SIZE = 'w342';
+
+export type MovieMetadata = {
+  tmdb?: {
+    release_date?: string | null;
+  } | null;
+  release_date?: string | null;
+  releaseDate?: string | null;
+};
+
+export const parseMovieReleaseYear = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const typedMetadata = metadata as MovieMetadata;
+  const releaseDate =
+    typedMetadata.tmdb?.release_date ?? typedMetadata.release_date ?? typedMetadata.releaseDate;
+
+  if (typeof releaseDate !== 'string' || releaseDate.length < 4) {
+    return null;
+  }
+
+  return releaseDate.slice(0, 4);
+};

--- a/lib/movies.ts
+++ b/lib/movies.ts
@@ -1,34 +1,12 @@
-import { supabaseAdminClient } from './supabaseAdminClient';
+import { MOVIE_POSTER_SIZE, parseMovieReleaseYear } from './movieMetadata';
 import { getMovieItemTypeId } from './itemTypes';
-
-export const MOVIE_POSTER_SIZE = 'w342';
+import { supabaseAdminClient } from './supabaseAdminClient';
 
 export type MovieRecord = {
   id: number;
   name: string;
   image_path: string | null;
   metadata: Record<string, unknown> | null;
-};
-
-export const parseMovieReleaseYear = (metadata: unknown): string | null => {
-  if (!metadata || typeof metadata !== 'object') {
-    return null;
-  }
-
-  const typedMetadata = metadata as {
-    tmdb?: { release_date?: string | null };
-    release_date?: string | null;
-    releaseDate?: string | null;
-  };
-
-  const releaseDate =
-    typedMetadata.tmdb?.release_date ?? typedMetadata.release_date ?? typedMetadata.releaseDate;
-
-  if (typeof releaseDate !== 'string' || releaseDate.length < 4) {
-    return null;
-  }
-
-  return releaseDate.slice(0, 4);
 };
 
 export const fetchMovieRecords = async (): Promise<MovieRecord[]> => {
@@ -46,3 +24,5 @@ export const fetchMovieRecords = async (): Promise<MovieRecord[]> => {
 
   return (data ?? []) as MovieRecord[];
 };
+
+export { MOVIE_POSTER_SIZE, parseMovieReleaseYear };

--- a/supabase/migrations/20250211000001_create_movie_comparison_function.sql
+++ b/supabase/migrations/20250211000001_create_movie_comparison_function.sql
@@ -1,0 +1,133 @@
+-- Migration: Create function to process movie matchup results
+-- Description: Adds a helper that updates Elo ratings for a winner/loser pair within a group.
+
+set check_function_bodies = off;
+
+create or replace function public.process_group_movie_comparison(
+  p_user_id uuid,
+  p_group_id uuid,
+  p_winner_item_id integer,
+  p_loser_item_id integer,
+  p_base_rating numeric default 1200,
+  p_provisional_k numeric default 40,
+  p_established_k numeric default 20,
+  p_master_k numeric default 10
+) returns table (
+  winner_item_id integer,
+  winner_rating numeric,
+  winner_comparison_count integer,
+  loser_item_id integer,
+  loser_rating numeric,
+  loser_comparison_count integer
+) language plpgsql security definer as
+$$
+declare
+  v_winner_rating numeric := p_base_rating;
+  v_loser_rating numeric := p_base_rating;
+  v_winner_count integer := 0;
+  v_loser_count integer := 0;
+  v_expected_winner numeric;
+  v_expected_loser numeric;
+  v_winner_k numeric;
+  v_loser_k numeric;
+  v_updated_winner_rating numeric;
+  v_updated_loser_rating numeric;
+  v_updated_winner_count integer;
+  v_updated_loser_count integer;
+begin
+  perform set_config('search_path', 'public', true);
+
+  if p_winner_item_id = p_loser_item_id then
+    raise exception 'Winner and loser must reference different items.';
+  end if;
+
+  perform 1
+  from public.group_items gi
+  where gi.group_id = p_group_id
+    and gi.item_id = p_winner_item_id;
+
+  if not found then
+    raise exception 'Winner item % does not belong to group %.', p_winner_item_id, p_group_id;
+  end if;
+
+  perform 1
+  from public.group_items gi
+  where gi.group_id = p_group_id
+    and gi.item_id = p_loser_item_id;
+
+  if not found then
+    raise exception 'Loser item % does not belong to group %.', p_loser_item_id, p_group_id;
+  end if;
+
+  insert into public.user_group_item_ratings (user_id, group_id, item_id, rating, comparison_count)
+  values (p_user_id, p_group_id, p_winner_item_id, p_base_rating, 0)
+  on conflict (user_id, group_id, item_id) do nothing;
+
+  insert into public.user_group_item_ratings (user_id, group_id, item_id, rating, comparison_count)
+  values (p_user_id, p_group_id, p_loser_item_id, p_base_rating, 0)
+  on conflict (user_id, group_id, item_id) do nothing;
+
+  select rating, comparison_count
+    into v_winner_rating, v_winner_count
+  from public.user_group_item_ratings
+  where user_id = p_user_id
+    and group_id = p_group_id
+    and item_id = p_winner_item_id
+  for update;
+
+  select rating, comparison_count
+    into v_loser_rating, v_loser_count
+  from public.user_group_item_ratings
+  where user_id = p_user_id
+    and group_id = p_group_id
+    and item_id = p_loser_item_id
+  for update;
+
+  v_expected_winner := 1 / (1 + power(10, (v_loser_rating - v_winner_rating) / 400.0));
+  v_expected_loser := 1 / (1 + power(10, (v_winner_rating - v_loser_rating) / 400.0));
+
+  v_winner_k := case
+    when v_winner_count <= 10 then p_provisional_k
+    when v_winner_count <= 30 then p_established_k
+    else p_master_k
+  end;
+
+  v_loser_k := case
+    when v_loser_count <= 10 then p_provisional_k
+    when v_loser_count <= 30 then p_established_k
+    else p_master_k
+  end;
+
+  v_updated_winner_rating := v_winner_rating + v_winner_k * (1 - v_expected_winner);
+  v_updated_loser_rating := v_loser_rating + v_loser_k * (0 - v_expected_loser);
+
+  update public.user_group_item_ratings
+     set rating = round(v_updated_winner_rating, 4),
+         comparison_count = v_winner_count + 1
+   where user_id = p_user_id
+     and group_id = p_group_id
+     and item_id = p_winner_item_id
+   returning rating, comparison_count
+    into v_updated_winner_rating, v_updated_winner_count;
+
+  update public.user_group_item_ratings
+     set rating = round(v_updated_loser_rating, 4),
+         comparison_count = v_loser_count + 1
+   where user_id = p_user_id
+     and group_id = p_group_id
+     and item_id = p_loser_item_id
+   returning rating, comparison_count
+    into v_updated_loser_rating, v_updated_loser_count;
+
+  return query
+  select p_winner_item_id,
+         v_updated_winner_rating,
+         v_updated_winner_count,
+         p_loser_item_id,
+         v_updated_loser_rating,
+         v_updated_loser_count;
+end;
+$$;
+
+comment on function public.process_group_movie_comparison(uuid, uuid, integer, integer, numeric, numeric, numeric, numeric)
+  is 'Updates Elo ratings for a user''s movie matchup within a ranking group.';


### PR DESCRIPTION
## Summary
- add a match endpoint that surfaces personalized movie pairings and posts Elo comparison results through a new SQL helper
- build a group comparison page with a client-side arena that fetches matchups, records choices, and renders poster art
- share movie metadata utilities and refresh messaging/documentation to point to the new ranking flow

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1813a4e10832e9ddc637c94096b75