### PR TITLE
Add navigation bar for authenticated pages

### DIFF
--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -1,23 +1,27 @@
 import React from 'react';
 
+import NavigationBar from '@/app/components/NavigationBar';
 import AuthForm from './AuthForm';
 
 const HomePage = () => {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 px-4 text-white">
-      <div className="flex w-full max-w-5xl flex-col items-center gap-10 md:flex-row md:items-start md:justify-between">
-        <div className="max-w-2xl text-center md:text-left">
-          <h1 className="text-5xl font-bold md:text-6xl">Welcome to MovElo</h1>
-          <p className="mt-4 text-lg text-gray-200 md:text-xl">
-            MovElo is your personal movie ranking companion. Compare your favorite films to build a definitive list that reflects
-            your taste.
-          </p>
-          <p className="mt-4 text-base text-gray-300">
-            Create an account or sign in to start saving your match-ups and track how your rankings change over time.
-          </p>
+    <div className="flex min-h-screen flex-col bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="flex flex-1 items-center justify-center px-4 py-12">
+        <div className="flex w-full max-w-5xl flex-col items-center gap-10 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-2xl text-center md:text-left">
+            <h1 className="text-5xl font-bold md:text-6xl">Welcome to MovElo</h1>
+            <p className="mt-4 text-lg text-gray-200 md:text-xl">
+              MovElo is your personal movie ranking companion. Compare your favorite films to build a definitive list that
+              reflects your taste.
+            </p>
+            <p className="mt-4 text-base text-gray-300">
+              Create an account or sign in to start saving your match-ups and track how your rankings change over time.
+            </p>
+          </div>
+          <AuthForm />
         </div>
-        <AuthForm />
-      </div>
+      </main>
     </div>
   );
 };

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { supabase } from '@/lib/supabaseClient';
+
+const NAV_LINKS = [
+  { href: '/movies', label: 'Movies' },
+  { href: '/groups/new', label: 'Create group' },
+] as const;
+
+const NavigationBar = () => {
+  const router = useRouter();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [sessionChecked, setSessionChecked] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const syncSession = async () => {
+      try {
+        const { data, error: sessionError } = await supabase.auth.getSession();
+
+        if (!isMounted) {
+          return;
+        }
+
+        if (sessionError) {
+          console.warn('Failed to load Supabase session:', sessionError);
+          setUserEmail(null);
+        } else {
+          setUserEmail(data.session?.user?.email ?? null);
+        }
+      } catch (sessionError) {
+        if (!isMounted) {
+          return;
+        }
+
+        console.warn('Failed to load Supabase session:', sessionError);
+        setUserEmail(null);
+      } finally {
+        if (isMounted) {
+          setSessionChecked(true);
+        }
+      }
+    };
+
+    void syncSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setUserEmail(session?.user?.email ?? null);
+      setSessionChecked(true);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    setError(null);
+
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+
+      if (signOutError) {
+        setError(signOutError.message);
+        return;
+      }
+
+      setUserEmail(null);
+      router.push('/');
+      router.refresh();
+    } catch (signOutError) {
+      const message =
+        signOutError instanceof Error
+          ? signOutError.message
+          : 'Unexpected error while signing out.';
+      setError(message);
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
+  if (!sessionChecked || !userEmail) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-gray-800 bg-gray-950/70 text-white backdrop-blur">
+      <nav className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6">
+        <div className="flex items-center justify-between gap-4 sm:justify-start">
+          <Link href="/" className="text-lg font-semibold text-white transition hover:text-blue-400">
+            MovElo
+          </Link>
+          <div className="flex items-center gap-4 text-sm font-medium text-gray-300 sm:hidden">
+            {NAV_LINKS.map((link) => (
+              <Link key={link.href} href={link.href} className="transition hover:text-white">
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-4 sm:justify-end">
+          <div className="hidden items-center gap-4 text-sm font-medium text-gray-300 sm:flex">
+            {NAV_LINKS.map((link) => (
+              <Link key={link.href} href={link.href} className="transition hover:text-white">
+                {link.label}
+              </Link>
+            ))}
+          </div>
+          <div className="hidden h-6 w-px bg-gray-800 sm:block" aria-hidden="true" />
+          <div className="flex items-center gap-3">
+            <span className="hidden text-sm text-gray-400 sm:inline" title={userEmail ?? undefined}>
+              {userEmail}
+            </span>
+            <button
+              type="button"
+              onClick={handleSignOut}
+              disabled={signingOut}
+              className="rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {signingOut ? 'Signing out…' : 'Sign out'}
+            </button>
+          </div>
+        </div>
+      </nav>
+      {error ? (
+        <div className="border-t border-red-500/40 bg-red-950/40 px-4 py-2 text-sm text-red-200 sm:px-6">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default NavigationBar;

--- a/app/groups/[groupId]/compare/ComparisonPage.tsx
+++ b/app/groups/[groupId]/compare/ComparisonPage.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import NavigationBar from '@/app/components/NavigationBar';
+
 import { supabase } from '@/lib/supabaseClient';
 
 type MatchupItem = {
@@ -253,52 +255,55 @@ const ComparisonPage = ({ groupId }: ComparisonPageProps) => {
   }, [accessToken, loading, matchup, sessionChecked]);
 
   return (
-    <div className="mx-auto flex min-h-[70vh] max-w-5xl flex-col gap-8 px-6 py-10 text-white sm:py-12 lg:px-8">
-      <div>
-        <h1 className="text-3xl font-semibold sm:text-4xl">Which option do you prefer?</h1>
-        <p className="mt-2 text-sm text-gray-300 sm:text-base">{helperText}</p>
-      </div>
+    <div className="min-h-screen bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="mx-auto flex min-h-[70vh] max-w-5xl flex-col gap-8 px-6 py-10 sm:py-12 lg:px-8">
+        <div>
+          <h1 className="text-3xl font-semibold sm:text-4xl">Which option do you prefer?</h1>
+          <p className="mt-2 text-sm text-gray-300 sm:text-base">{helperText}</p>
+        </div>
 
-      {error && (
-        <div className="rounded-lg border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200">
-          {error}
-          {accessToken && (
-            <button
-              type="button"
-              onClick={handleRetry}
-              className="ml-4 inline-flex items-center gap-2 rounded-md border border-red-400/40 px-3 py-1 text-xs font-medium text-red-100 transition hover:border-red-300 hover:text-white"
-              disabled={loading}
-            >
-              Try again
-            </button>
+        {error && (
+          <div className="rounded-lg border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+            {accessToken && (
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="ml-4 inline-flex items-center gap-2 rounded-md border border-red-400/40 px-3 py-1 text-xs font-medium text-red-100 transition hover:border-red-300 hover:text-white"
+                disabled={loading}
+              >
+                Try again
+              </button>
+            )}
+          </div>
+        )}
+
+        <div className="grid flex-1 gap-6 sm:gap-8 md:grid-cols-2">
+          {matchup?.itemA ? (
+            <ComparisonOption
+              item={matchup.itemA}
+              disabled={loading || !accessToken}
+              onSelect={() => handleChoice(matchup.itemA.id, matchup.itemB.id)}
+            />
+          ) : (
+            <div className="flex items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-950/40 p-6 text-sm text-gray-400">
+              {loading ? 'Preparing matchup…' : 'Waiting for matchup data.'}
+            </div>
+          )}
+          {matchup?.itemB ? (
+            <ComparisonOption
+              item={matchup.itemB}
+              disabled={loading || !accessToken}
+              onSelect={() => handleChoice(matchup.itemB.id, matchup.itemA.id)}
+            />
+          ) : (
+            <div className="flex items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-950/40 p-6 text-sm text-gray-400">
+              {loading ? 'Preparing matchup…' : 'Waiting for matchup data.'}
+            </div>
           )}
         </div>
-      )}
-
-      <div className="grid flex-1 gap-6 sm:gap-8 md:grid-cols-2">
-        {matchup?.itemA ? (
-          <ComparisonOption
-            item={matchup.itemA}
-            disabled={loading || !accessToken}
-            onSelect={() => handleChoice(matchup.itemA.id, matchup.itemB.id)}
-          />
-        ) : (
-          <div className="flex items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-950/40 p-6 text-sm text-gray-400">
-            {loading ? 'Preparing matchup…' : 'Waiting for matchup data.'}
-          </div>
-        )}
-        {matchup?.itemB ? (
-          <ComparisonOption
-            item={matchup.itemB}
-            disabled={loading || !accessToken}
-            onSelect={() => handleChoice(matchup.itemB.id, matchup.itemA.id)}
-          />
-        ) : (
-          <div className="flex items-center justify-center rounded-xl border border-dashed border-gray-800 bg-gray-950/40 p-6 text-sm text-gray-400">
-            {loading ? 'Preparing matchup…' : 'Waiting for matchup data.'}
-          </div>
-        )}
-      </div>
+      </main>
     </div>
   );
 };

--- a/app/groups/new/page.tsx
+++ b/app/groups/new/page.tsx
@@ -1,3 +1,5 @@
+import NavigationBar from '@/app/components/NavigationBar';
+
 import CreateMovieGroupForm from './CreateMovieGroupForm';
 
 import { MOVIE_POSTER_SIZE, fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
@@ -16,8 +18,9 @@ export default async function CreateGroupPage() {
   }));
 
   return (
-    <main className="min-h-screen bg-gray-900 px-6 py-12 text-white">
-      <div className="mx-auto w-full max-w-6xl">
+    <div className="min-h-screen bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="mx-auto w-full max-w-6xl px-6 py-12">
         <header className="flex flex-col gap-4 text-center sm:text-left">
           <h1 className="text-4xl font-bold sm:text-5xl">Create a movie ranking group</h1>
           <p className="text-lg text-gray-300">
@@ -27,7 +30,7 @@ export default async function CreateGroupPage() {
         </header>
 
         <CreateMovieGroupForm movies={movieOptions} />
-      </div>
-    </main>
+      </main>
+    </div>
   );
 }

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,3 +1,5 @@
+import NavigationBar from '@/app/components/NavigationBar';
+
 import MoviePoster from '../components/MoviePoster';
 
 import { MOVIE_POSTER_SIZE, fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
@@ -15,8 +17,9 @@ export default async function MoviesPage() {
   }));
 
   return (
-    <main className="min-h-screen bg-gray-900 px-6 py-12 text-white">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+    <div className="min-h-screen bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-12">
         <header className="flex flex-col gap-4 text-center sm:text-left">
           <h1 className="text-4xl font-bold sm:text-5xl">Movie Library</h1>
           <p className="text-lg text-gray-300">
@@ -51,7 +54,7 @@ export default async function MoviesPage() {
             ))}
           </ul>
         )}
-      </div>
-    </main>
+      </main>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,5 @@
 import HomePage from './components/HomePage';
 
 export default function Home() {
-  return (
-    <main>
-      <HomePage />
-    </main>
-  );
+  return <HomePage />;
 }


### PR DESCRIPTION
## Summary
- add a reusable NavigationBar component that checks the Supabase session, shows key links, and lets users sign out
- render the navigation bar on the home screen, movie library, group creation, and comparison experiences so logged-in users can move between sections

## Testing
- npm run build *(fails: Next.js could not download the Google Fonts required by the Geist family in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18d4aa7ec832e936d213e8ecf61fa