### PR TITLE
Add group selection page for rating UI navigation

### DIFF
--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -8,6 +8,7 @@ import { supabase } from '@/lib/supabaseClient';
 
 const NAV_LINKS = [
   { href: '/movies', label: 'Movies' },
+  { href: '/groups', label: 'Groups' },
   { href: '/groups/new', label: 'Create group' },
 ] as const;
 

--- a/app/groups/new/CreateMovieGroupForm.tsx
+++ b/app/groups/new/CreateMovieGroupForm.tsx
@@ -135,8 +135,8 @@ const CreateMovieGroupForm = ({ movies }: CreateMovieGroupFormProps) => {
       const createdMovieCount = payload.movieCount ?? selectedMovies.size;
 
       setSuccessMessage(
-        `Group created successfully with ${createdMovieCount} movie${createdMovieCount === 1 ? '' : 's'}. Save the ID ` +
-          `(${payload.groupId}) to reference it later.`
+        `Group created successfully with ${createdMovieCount} movie${createdMovieCount === 1 ? '' : 's'}. ` +
+          `Share the ID (${payload.groupId}) to invite friends or visit the groups page to start ranking.`
       );
       setGroupName('');
       setGroupDescription('');

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+
+import NavigationBar from '@/app/components/NavigationBar';
+
+import { fetchMovieRankingGroups } from '@/lib/groups';
+
+export const revalidate = 0;
+
+const FALLBACK_DESCRIPTION = 'No description provided for this group yet.';
+
+export default async function GroupSelectionPage() {
+  const groups = await fetchMovieRankingGroups();
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-12">
+        <header className="flex flex-col gap-4 text-center sm:text-left">
+          <h1 className="text-4xl font-bold sm:text-5xl">Choose a ranking group</h1>
+          <p className="text-lg text-gray-300">
+            Pick a group to jump into the head-to-head rating experience.
+          </p>
+        </header>
+
+        {groups.length === 0 ? (
+          <section className="rounded-lg border border-gray-800 bg-gray-950/60 px-6 py-10 text-center shadow-lg shadow-black/30 sm:text-left">
+            <h2 className="text-2xl font-semibold text-white">No groups found</h2>
+            <p className="mt-3 text-sm text-gray-300">
+              Create a ranking group to get started, then invite friends to help build the list.
+            </p>
+            <div className="mt-6 flex justify-center sm:justify-start">
+              <Link
+                href="/groups/new"
+                className="inline-flex items-center gap-2 rounded-md bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+              >
+                Create a group
+              </Link>
+            </div>
+          </section>
+        ) : (
+          <ul className="grid gap-6 md:grid-cols-2">
+            {groups.map((group) => {
+              const description = group.description?.trim();
+
+              return (
+                <li key={group.id} className="h-full">
+                  <Link
+                    href={`/groups/${group.id}/compare`}
+                    className="flex h-full flex-col justify-between gap-6 rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30 transition hover:border-blue-500 hover:bg-gray-900/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                  >
+                    <div className="space-y-3">
+                      <h2 className="text-2xl font-semibold text-white">{group.name}</h2>
+                      <p className="text-sm text-gray-300">
+                        {description && description.length > 0 ? description : FALLBACK_DESCRIPTION}
+                      </p>
+                    </div>
+                    <div className="flex items-center justify-between text-xs font-medium">
+                      <span className="font-mono text-gray-500" aria-label="Group identifier">
+                        {group.id}
+                      </span>
+                      <span className="text-blue-400">Start ranking →</span>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/lib/groups.ts
+++ b/lib/groups.ts
@@ -1,0 +1,50 @@
+import { getMovieItemTypeId } from './itemTypes';
+import { supabaseAdminClient } from './supabaseAdminClient';
+
+export type MovieRankingGroup = {
+  id: string;
+  name: string;
+  description: string | null;
+};
+
+export const fetchMovieRankingGroups = async (): Promise<MovieRankingGroup[]> => {
+  const movieItemTypeId = await getMovieItemTypeId();
+
+  const { data, error } = await supabaseAdminClient
+    .from('ranking_groups')
+    .select('id, name, description')
+    .eq('item_type_id', movieItemTypeId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  const rawEntries: unknown[] = Array.isArray(data) ? data : [];
+
+  const groups: MovieRankingGroup[] = [];
+
+  for (const rawEntry of rawEntries) {
+    if (!rawEntry || typeof rawEntry !== 'object') {
+      continue;
+    }
+
+    const { id, name, description } = rawEntry as {
+      id?: unknown;
+      name?: unknown;
+      description?: unknown;
+    };
+
+    if (typeof id !== 'string' || typeof name !== 'string') {
+      continue;
+    }
+
+    groups.push({
+      id,
+      name,
+      description: typeof description === 'string' ? description : null,
+    });
+  }
+
+  return groups;
+};


### PR DESCRIPTION
## Summary
- add a server-rendered /groups page that lists available movie ranking groups and links to the comparison UI for each one
- introduce a Supabase helper to fetch movie groups for the new page
- update navigation and the group creation success message to point participants toward the group selection flow

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d191d02ee4832eba19b53d15c3a023