### PR TITLE
Add user ratings page with group selection

### DIFF
--- a/app/api/matchup/route.ts
+++ b/app/api/matchup/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { MOVIE_POSTER_SIZE } from '@/lib/movies';
+import { MOVIE_POSTER_SIZE } from '@/lib/moviePresentation';
 import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
 import { buildPosterUrl, getTmdbConfiguration } from '@/lib/tmdb';
 

--- a/app/api/user/groups/route.ts
+++ b/app/api/user/groups/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+
+import { getMovieItemTypeId } from '@/lib/itemTypes';
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+
+type GroupSummary = {
+  id: string;
+  name: string;
+  description: string | null;
+};
+
+type ParticipantRow = {
+  group_id?: unknown;
+};
+
+type GroupRow = {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+};
+
+const extractBearerToken = (request: Request): string | null => {
+  const authorization = request.headers.get('authorization') ?? request.headers.get('Authorization');
+
+  if (!authorization || !authorization.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  const token = authorization.slice('bearer '.length).trim();
+
+  return token || null;
+};
+
+const normalizeGroupRow = (value: GroupRow): GroupSummary | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const { id, name, description } = value;
+
+  if (typeof id !== 'string' || id.trim().length === 0) {
+    return null;
+  }
+
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return null;
+  }
+
+  return {
+    id: id.trim(),
+    name: name.trim(),
+    description: typeof description === 'string' && description.trim().length > 0 ? description.trim() : null,
+  };
+};
+
+const extractParticipantGroupIds = (rows: ParticipantRow[]): string[] => {
+  const uniqueIds = new Set<string>();
+
+  for (const row of rows) {
+    const identifier = row?.group_id;
+
+    if (typeof identifier === 'string' && identifier.trim().length > 0) {
+      uniqueIds.add(identifier.trim());
+      continue;
+    }
+
+    if (typeof identifier === 'number' && Number.isFinite(identifier)) {
+      uniqueIds.add(String(identifier));
+    }
+  }
+
+  return Array.from(uniqueIds);
+};
+
+export async function GET(request: Request) {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  const { data: userResult, error: userError } = await supabaseAdminClient.auth.getUser(token);
+
+  if (userError || !userResult?.user) {
+    return NextResponse.json({ error: 'User session could not be verified.' }, { status: 401 });
+  }
+
+  const userId = userResult.user.id;
+
+  try {
+    const { data: participantRows, error: participantError } = await supabaseAdminClient
+      .from('group_participants')
+      .select('group_id')
+      .eq('user_id', userId);
+
+    if (participantError) {
+      throw participantError;
+    }
+
+    const groupIds = extractParticipantGroupIds((participantRows ?? []) as ParticipantRow[]);
+
+    if (groupIds.length === 0) {
+      return NextResponse.json({ groups: [] });
+    }
+
+    const movieItemTypeId = await getMovieItemTypeId();
+
+    const { data: groupRows, error: groupsError } = await supabaseAdminClient
+      .from('ranking_groups')
+      .select('id, name, description')
+      .in('id', groupIds)
+      .eq('item_type_id', movieItemTypeId)
+      .order('name', { ascending: true });
+
+    if (groupsError) {
+      throw groupsError;
+    }
+
+    const normalizedGroups: GroupSummary[] = [];
+
+    for (const row of (groupRows ?? []) as GroupRow[]) {
+      const normalized = normalizeGroupRow(row);
+
+      if (normalized) {
+        normalizedGroups.push(normalized);
+      }
+    }
+
+    return NextResponse.json({ groups: normalizedGroups });
+  } catch (error) {
+    console.error('Failed to load user ranking groups:', error);
+    return NextResponse.json({ error: 'Failed to load user ranking groups.' }, { status: 500 });
+  }
+}

--- a/app/api/user/ratings/route.ts
+++ b/app/api/user/ratings/route.ts
@@ -1,0 +1,273 @@
+import { NextResponse } from 'next/server';
+
+import { supabaseAdminClient } from '@/lib/supabaseAdminClient';
+
+type RawRankableItem = {
+  id?: unknown;
+  name?: unknown;
+  image_path?: unknown;
+};
+
+type RawGroupItemRow = {
+  item_id?: unknown;
+  rankable_items?: RawRankableItem | RawRankableItem[] | null;
+};
+
+type RawRatingRow = {
+  item_id?: unknown;
+  rating?: unknown;
+  comparison_count?: unknown;
+};
+
+type UserRatingItem = {
+  itemId: number;
+  name: string;
+  posterPath: string | null;
+  rating: number;
+  comparisonCount: number;
+};
+
+const BASE_RATING = 1500;
+
+const extractBearerToken = (request: Request): string | null => {
+  const authorization = request.headers.get('authorization') ?? request.headers.get('Authorization');
+
+  if (!authorization || !authorization.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  const token = authorization.slice('bearer '.length).trim();
+
+  return token || null;
+};
+
+const parseInteger = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(trimmed, 10);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const parseRankableItem = (value: RawRankableItem | null | undefined): {
+  id: number;
+  name: string;
+  imagePath: string | null;
+} | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const { id, name, image_path: imagePath } = value;
+
+  const normalizedId = parseInteger(id);
+
+  if (normalizedId === null) {
+    return null;
+  }
+
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return null;
+  }
+
+  const normalizedImagePath =
+    typeof imagePath === 'string' && imagePath.trim().length > 0 ? imagePath.trim() : null;
+
+  return {
+    id: normalizedId,
+    name: name.trim(),
+    imagePath: normalizedImagePath,
+  };
+};
+
+const parseGroupItemRow = (value: RawGroupItemRow): {
+  itemId: number;
+  name: string;
+  imagePath: string | null;
+} | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const normalizedItemId = parseInteger(value.item_id);
+  const rawItem = Array.isArray(value.rankable_items)
+    ? value.rankable_items.at(0)
+    : value.rankable_items;
+
+  const parsedItem = parseRankableItem(rawItem ?? null);
+
+  if (!parsedItem) {
+    return null;
+  }
+
+  return {
+    itemId: normalizedItemId ?? parsedItem.id,
+    name: parsedItem.name,
+    imagePath: parsedItem.imagePath,
+  };
+};
+
+const parseRatingRow = (value: RawRatingRow): {
+  itemId: number;
+  rating: number;
+  comparisonCount: number;
+} | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const itemId = parseInteger(value.item_id);
+
+  if (itemId === null) {
+    return null;
+  }
+
+  const ratingValue =
+    typeof value.rating === 'number'
+      ? value.rating
+      : Number.parseFloat(String(value.rating ?? ''));
+
+  const comparisonValue =
+    typeof value.comparison_count === 'number'
+      ? value.comparison_count
+      : Number.parseInt(String(value.comparison_count ?? '0'), 10);
+
+  return {
+    itemId,
+    rating: Number.isFinite(ratingValue) ? ratingValue : BASE_RATING,
+    comparisonCount: Number.isFinite(comparisonValue) ? comparisonValue : 0,
+  };
+};
+
+export async function GET(request: Request) {
+  const token = extractBearerToken(request);
+
+  if (!token) {
+    return NextResponse.json({ error: 'Authorization token is required.' }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const groupId = url.searchParams.get('groupId');
+
+  if (!groupId) {
+    return NextResponse.json({ error: 'A groupId query parameter is required.' }, { status: 400 });
+  }
+
+  const { data: userResult, error: userError } = await supabaseAdminClient.auth.getUser(token);
+
+  if (userError || !userResult?.user) {
+    return NextResponse.json({ error: 'User session could not be verified.' }, { status: 401 });
+  }
+
+  const userId = userResult.user.id;
+
+  try {
+    const { data: participant, error: participantError } = await supabaseAdminClient
+      .from('group_participants')
+      .select('user_id')
+      .eq('group_id', groupId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (participantError) {
+      throw participantError;
+    }
+
+    if (!participant) {
+      return NextResponse.json({ error: 'You are not a participant in this ranking group.' }, { status: 403 });
+    }
+
+    const { data: groupItems, error: groupItemsError } = await supabaseAdminClient
+      .from('group_items')
+      .select('item_id, rankable_items(id, name, image_path)')
+      .eq('group_id', groupId);
+
+    if (groupItemsError) {
+      throw groupItemsError;
+    }
+
+    const normalizedItems = [] as {
+      itemId: number;
+      name: string;
+      imagePath: string | null;
+    }[];
+
+    for (const row of (groupItems ?? []) as RawGroupItemRow[]) {
+      const parsed = parseGroupItemRow(row);
+
+      if (parsed) {
+        normalizedItems.push(parsed);
+      }
+    }
+
+    if (normalizedItems.length === 0) {
+      return NextResponse.json({ groupId, items: [] });
+    }
+
+    const { data: ratingRows, error: ratingsError } = await supabaseAdminClient
+      .from('user_group_item_ratings')
+      .select('item_id, rating, comparison_count')
+      .eq('group_id', groupId)
+      .eq('user_id', userId);
+
+    if (ratingsError) {
+      throw ratingsError;
+    }
+
+    const ratingMap = new Map<number, { rating: number; comparisonCount: number }>();
+
+    for (const row of (ratingRows ?? []) as RawRatingRow[]) {
+      const parsed = parseRatingRow(row);
+
+      if (parsed) {
+        ratingMap.set(parsed.itemId, {
+          rating: parsed.rating,
+          comparisonCount: parsed.comparisonCount,
+        });
+      }
+    }
+
+    const responseItems: UserRatingItem[] = normalizedItems.map((item) => {
+      const existing = ratingMap.get(item.itemId);
+
+      return {
+        itemId: item.itemId,
+        name: item.name,
+        posterPath: item.imagePath,
+        rating: existing?.rating ?? BASE_RATING,
+        comparisonCount: existing?.comparisonCount ?? 0,
+      } satisfies UserRatingItem;
+    });
+
+    responseItems.sort((a, b) => {
+      if (b.rating !== a.rating) {
+        return b.rating - a.rating;
+      }
+
+      if (b.comparisonCount !== a.comparisonCount) {
+        return b.comparisonCount - a.comparisonCount;
+      }
+
+      return a.name.localeCompare(b.name);
+    });
+
+    return NextResponse.json({ groupId, items: responseItems });
+  } catch (error) {
+    console.error('Failed to load user ratings:', error);
+    return NextResponse.json({ error: 'Failed to load user ratings.' }, { status: 500 });
+  }
+}

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/lib/supabaseClient';
 const NAV_LINKS = [
   { href: '/movies', label: 'Movies' },
   { href: '/groups', label: 'Groups' },
+  { href: '/ratings', label: 'My ratings' },
   { href: '/groups/new', label: 'Create group' },
 ] as const;
 

--- a/app/groups/new/page.tsx
+++ b/app/groups/new/page.tsx
@@ -2,7 +2,8 @@ import NavigationBar from '@/app/components/NavigationBar';
 
 import CreateMovieGroupForm from './CreateMovieGroupForm';
 
-import { MOVIE_POSTER_SIZE, fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
+import { fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
+import { MOVIE_POSTER_SIZE } from '@/lib/moviePresentation';
 import { buildPosterUrl, getTmdbConfiguration } from '@/lib/tmdb';
 
 export const revalidate = 0;

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -2,7 +2,8 @@ import NavigationBar from '@/app/components/NavigationBar';
 
 import MoviePoster from '../components/MoviePoster';
 
-import { MOVIE_POSTER_SIZE, fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
+import { fetchMovieRecords, parseMovieReleaseYear } from '@/lib/movies';
+import { MOVIE_POSTER_SIZE } from '@/lib/moviePresentation';
 import { buildPosterUrl, getTmdbConfiguration } from '@/lib/tmdb';
 
 export const revalidate = 0;

--- a/app/ratings/UserRatingsExplorer.tsx
+++ b/app/ratings/UserRatingsExplorer.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import MoviePoster from '@/app/components/MoviePoster';
-import { MOVIE_POSTER_SIZE } from '@/lib/movies';
+import { MOVIE_POSTER_SIZE } from '@/lib/moviePresentation';
 import { supabase } from '@/lib/supabaseClient';
 import { buildPosterUrl, type TmdbConfigurationResponse } from '@/lib/tmdb';
 

--- a/app/ratings/UserRatingsExplorer.tsx
+++ b/app/ratings/UserRatingsExplorer.tsx
@@ -1,0 +1,517 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import MoviePoster from '@/app/components/MoviePoster';
+import { MOVIE_POSTER_SIZE } from '@/lib/movies';
+import { supabase } from '@/lib/supabaseClient';
+import { buildPosterUrl, type TmdbConfigurationResponse } from '@/lib/tmdb';
+
+type GroupOption = {
+  id: string;
+  name: string;
+  description: string | null;
+};
+
+type RatingItem = {
+  itemId: number;
+  name: string;
+  posterPath: string | null;
+  rating: number;
+  comparisonCount: number;
+};
+
+type GroupsResponsePayload = {
+  groups?: unknown;
+  error?: unknown;
+};
+
+type RatingsResponsePayload = {
+  items?: unknown;
+  error?: unknown;
+};
+
+const BASE_RATING = 1500;
+
+const parseErrorMessage = (payload: unknown, fallback: string): string => {
+  if (payload && typeof payload === 'object' && 'error' in payload) {
+    const message = (payload as { error?: unknown }).error;
+
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+};
+
+const parseGroupsResponse = (payload: unknown): GroupOption[] => {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const groupsValue = (payload as GroupsResponsePayload).groups;
+
+  if (!Array.isArray(groupsValue)) {
+    return [];
+  }
+
+  const normalized: GroupOption[] = [];
+
+  for (const entry of groupsValue) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const { id, name, description } = entry as {
+      id?: unknown;
+      name?: unknown;
+      description?: unknown;
+    };
+
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      continue;
+    }
+
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      continue;
+    }
+
+    normalized.push({
+      id: id.trim(),
+      name: name.trim(),
+      description: typeof description === 'string' && description.trim().length > 0 ? description.trim() : null,
+    });
+  }
+
+  return normalized;
+};
+
+const parseRatingsResponse = (payload: unknown): RatingItem[] => {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const itemsValue = (payload as RatingsResponsePayload).items;
+
+  if (!Array.isArray(itemsValue)) {
+    return [];
+  }
+
+  const normalized: RatingItem[] = [];
+
+  for (const entry of itemsValue) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const { itemId, name, posterPath, rating, comparisonCount } = entry as {
+      itemId?: unknown;
+      name?: unknown;
+      posterPath?: unknown;
+      rating?: unknown;
+      comparisonCount?: unknown;
+    };
+
+    let normalizedId: number | null = null;
+
+    if (typeof itemId === 'number' && Number.isFinite(itemId)) {
+      normalizedId = Math.trunc(itemId);
+    } else if (typeof itemId === 'string') {
+      const parsed = Number.parseInt(itemId, 10);
+      if (Number.isFinite(parsed)) {
+        normalizedId = parsed;
+      }
+    }
+
+    if (normalizedId === null) {
+      continue;
+    }
+
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      continue;
+    }
+
+    const parsedRating =
+      typeof rating === 'number'
+        ? rating
+        : Number.parseFloat(typeof rating === 'string' ? rating : String(rating ?? ''));
+
+    const parsedComparisons =
+      typeof comparisonCount === 'number'
+        ? comparisonCount
+        : Number.parseInt(typeof comparisonCount === 'string' ? comparisonCount : String(comparisonCount ?? '0'), 10);
+
+    normalized.push({
+      itemId: normalizedId,
+      name: name.trim(),
+      posterPath:
+        typeof posterPath === 'string' && posterPath.trim().length > 0 ? posterPath.trim() : null,
+      rating: Number.isFinite(parsedRating) ? parsedRating : BASE_RATING,
+      comparisonCount: Number.isFinite(parsedComparisons) ? parsedComparisons : 0,
+    });
+  }
+
+  return normalized;
+};
+
+const formatRating = (value: number): string => {
+  return value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+};
+
+const formatComparisonLabel = (value: number): string => {
+  if (value === 1) {
+    return '1 comparison logged';
+  }
+
+  return `${value.toLocaleString(undefined, { maximumFractionDigits: 0 })} comparisons logged`;
+};
+
+const resolvePosterUrl = (
+  posterPath: string | null,
+  tmdbConfig: TmdbConfigurationResponse | null
+): string | null => {
+  if (!posterPath) {
+    return null;
+  }
+
+  if (posterPath.startsWith('http://') || posterPath.startsWith('https://')) {
+    return posterPath;
+  }
+
+  if (!tmdbConfig) {
+    return null;
+  }
+
+  return buildPosterUrl(tmdbConfig, posterPath, MOVIE_POSTER_SIZE);
+};
+
+type UserRatingsExplorerProps = {
+  tmdbConfig: TmdbConfigurationResponse | null;
+};
+
+const UserRatingsExplorer = ({ tmdbConfig }: UserRatingsExplorerProps) => {
+  const [sessionChecked, setSessionChecked] = useState(false);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [loadingGroups, setLoadingGroups] = useState(false);
+  const [groups, setGroups] = useState<GroupOption[]>([]);
+  const [groupsError, setGroupsError] = useState<string | null>(null);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [ratings, setRatings] = useState<RatingItem[]>([]);
+  const [ratingsError, setRatingsError] = useState<string | null>(null);
+  const [ratingsLoading, setRatingsLoading] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const syncSession = async () => {
+      try {
+        const { data } = await supabase.auth.getSession();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setAccessToken(data.session?.access_token ?? null);
+      } catch (error) {
+        console.warn('Failed to load Supabase session:', error);
+        if (isMounted) {
+          setAccessToken(null);
+        }
+      } finally {
+        if (isMounted) {
+          setSessionChecked(true);
+        }
+      }
+    };
+
+    void syncSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setAccessToken(session?.access_token ?? null);
+      setSessionChecked(true);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!sessionChecked) {
+      return;
+    }
+
+    if (!accessToken) {
+      setGroups([]);
+      setSelectedGroupId(null);
+      setGroupsError(null);
+      return;
+    }
+
+    let isActive = true;
+
+    const loadGroups = async () => {
+      setLoadingGroups(true);
+      setGroupsError(null);
+
+      try {
+        const response = await fetch('/api/user/groups', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => null);
+
+        if (!isActive) {
+          return;
+        }
+
+        if (!response.ok) {
+          const message = parseErrorMessage(payload, 'Failed to load your ranking groups.');
+          setGroupsError(message);
+          setGroups([]);
+          setSelectedGroupId(null);
+          return;
+        }
+
+        const normalized = parseGroupsResponse(payload);
+        setGroups(normalized);
+
+        setSelectedGroupId((previous) => {
+          if (previous && normalized.some((group) => group.id === previous)) {
+            return previous;
+          }
+
+          return normalized.at(0)?.id ?? null;
+        });
+      } catch (error) {
+        if (!isActive) {
+          return;
+        }
+
+        console.error('Failed to load ranking groups:', error);
+        setGroupsError('Failed to load your ranking groups.');
+        setGroups([]);
+        setSelectedGroupId(null);
+      } finally {
+        if (isActive) {
+          setLoadingGroups(false);
+        }
+      }
+    };
+
+    void loadGroups();
+
+    return () => {
+      isActive = false;
+    };
+  }, [accessToken, sessionChecked]);
+
+  useEffect(() => {
+    if (!accessToken || !selectedGroupId) {
+      setRatings([]);
+      setRatingsError(null);
+      return;
+    }
+
+    let isActive = true;
+
+    const loadRatings = async () => {
+      setRatingsLoading(true);
+      setRatingsError(null);
+
+      try {
+        const response = await fetch(`/api/user/ratings?groupId=${encodeURIComponent(selectedGroupId)}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        const payload = await response.json().catch(() => null);
+
+        if (!isActive) {
+          return;
+        }
+
+        if (!response.ok) {
+          const message = parseErrorMessage(payload, 'Failed to load your movie ratings.');
+          setRatingsError(message);
+          setRatings([]);
+          return;
+        }
+
+        const normalized = parseRatingsResponse(payload);
+        setRatings(normalized);
+      } catch (error) {
+        if (!isActive) {
+          return;
+        }
+
+        console.error('Failed to load user ratings:', error);
+        setRatingsError('Failed to load your movie ratings.');
+        setRatings([]);
+      } finally {
+        if (isActive) {
+          setRatingsLoading(false);
+        }
+      }
+    };
+
+    void loadRatings();
+
+    return () => {
+      isActive = false;
+    };
+  }, [accessToken, selectedGroupId]);
+
+  const selectedGroup = useMemo(() => {
+    if (!selectedGroupId) {
+      return null;
+    }
+
+    return groups.find((group) => group.id === selectedGroupId) ?? null;
+  }, [groups, selectedGroupId]);
+
+  const hasAnyComparisons = useMemo(() => {
+    return ratings.some((item) => item.comparisonCount > 0);
+  }, [ratings]);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold text-white">Choose a ranking group</h2>
+          <p className="text-sm text-gray-300">
+            Pick a group to inspect the Elo ratings you&apos;ve built through head-to-head matchups.
+          </p>
+        </div>
+
+        {!sessionChecked ? (
+          <p className="mt-4 text-sm text-gray-400">Checking your session…</p>
+        ) : !accessToken ? (
+          <p className="mt-4 text-sm text-gray-400">Sign in to view your personal ratings.</p>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {groupsError ? (
+              <div className="rounded-md border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                {groupsError}
+              </div>
+            ) : null}
+
+            {loadingGroups ? (
+              <p className="text-sm text-gray-400">Loading your groups…</p>
+            ) : groups.length === 0 ? (
+              <p className="text-sm text-gray-400">
+                You&apos;re not part of any ranking groups yet. Create one or ask a friend to invite you.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-4">
+                <label htmlFor="group-select" className="text-sm font-medium text-gray-200">
+                  Ranking group
+                </label>
+                <select
+                  id="group-select"
+                  value={selectedGroupId ?? ''}
+                  onChange={(event) => setSelectedGroupId(event.target.value || null)}
+                  className="mt-1 w-full rounded-md border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:w-80"
+                >
+                  {groups.map((group) => (
+                    <option key={group.id} value={group.id}>
+                      {group.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {selectedGroup ? (
+              <p className="text-sm text-gray-400">
+                {selectedGroup.description ?? 'No description provided for this group yet.'}
+              </p>
+            ) : null}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-gray-800 bg-gray-950/60 p-6 shadow-lg shadow-black/30">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold text-white">Movie ratings</h2>
+          <p className="text-sm text-gray-300">Movies are sorted from the highest Elo rating to the lowest.</p>
+        </div>
+
+        {!sessionChecked ? (
+          <p className="mt-4 text-sm text-gray-400">Checking your session…</p>
+        ) : !accessToken ? (
+          <p className="mt-4 text-sm text-gray-400">Sign in to review your ratings.</p>
+        ) : !selectedGroupId ? (
+          <p className="mt-4 text-sm text-gray-400">Choose a group above to view your movie list.</p>
+        ) : ratingsError ? (
+          <div className="mt-4 rounded-md border border-red-500/60 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {ratingsError}
+          </div>
+        ) : ratingsLoading ? (
+          <p className="mt-4 text-sm text-gray-400">Loading your ratings…</p>
+        ) : ratings.length === 0 ? (
+          <p className="mt-4 text-sm text-gray-400">This group doesn&apos;t have any movies yet.</p>
+        ) : (
+          <>
+            {!hasAnyComparisons ? (
+              <p className="mt-4 text-sm text-amber-200">
+                You haven&apos;t compared any movies in this group yet. All films are still at the starting Elo rating of{' '}
+                {formatRating(BASE_RATING)}.
+              </p>
+            ) : (
+              <p className="mt-4 text-xs text-gray-500">
+                New movies join at {formatRating(BASE_RATING)} Elo until you record matchups.
+              </p>
+            )}
+
+            <ol className="mt-6 space-y-4">
+              {ratings.map((item, index) => {
+                const posterUrl = resolvePosterUrl(item.posterPath, tmdbConfig);
+
+                return (
+                  <li
+                    key={item.itemId}
+                    className="flex flex-col gap-4 rounded-lg border border-gray-800 bg-gray-900/60 p-4 sm:flex-row sm:items-center sm:gap-6"
+                  >
+                    <div className="flex items-center gap-4">
+                      <span className="text-xl font-semibold text-blue-300 sm:text-2xl">#{index + 1}</span>
+                      <MoviePoster
+                        posterUrl={posterUrl}
+                        title={item.name}
+                        imageClassName="h-auto w-20 rounded-md object-cover shadow-md shadow-black/40 sm:w-24"
+                        placeholderClassName="flex h-32 w-20 items-center justify-center rounded-md bg-gray-800 text-xs text-gray-400 sm:w-24"
+                        sizes="96px"
+                      />
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2">
+                      <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between">
+                        <h3 className="text-lg font-semibold text-white sm:text-xl">{item.name}</h3>
+                        <span className="text-sm font-mono text-blue-300 sm:text-base">
+                          {formatRating(item.rating)} Elo
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-400">{formatComparisonLabel(item.comparisonCount)}</p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          </>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default UserRatingsExplorer;

--- a/app/ratings/page.tsx
+++ b/app/ratings/page.tsx
@@ -1,0 +1,36 @@
+import NavigationBar from '@/app/components/NavigationBar';
+
+import UserRatingsExplorer from './UserRatingsExplorer';
+
+import { getTmdbConfiguration } from '@/lib/tmdb';
+
+export const revalidate = 0;
+
+const RatingsPage = async () => {
+  let tmdbConfig: Awaited<ReturnType<typeof getTmdbConfiguration>> | null = null;
+
+  try {
+    tmdbConfig = await getTmdbConfiguration();
+  } catch (error) {
+    console.warn('TMDb configuration could not be loaded for the ratings page:', error);
+    tmdbConfig = null;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <NavigationBar />
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-12">
+        <header className="flex flex-col gap-4 text-center sm:text-left">
+          <h1 className="text-4xl font-bold sm:text-5xl">My movie ratings</h1>
+          <p className="text-lg text-gray-300">
+            Review how your Elo scores stack up across each ranking group you participate in.
+          </p>
+        </header>
+
+        <UserRatingsExplorer tmdbConfig={tmdbConfig} />
+      </main>
+    </div>
+  );
+};
+
+export default RatingsPage;

--- a/lib/moviePresentation.ts
+++ b/lib/moviePresentation.ts
@@ -1,0 +1,1 @@
+export const MOVIE_POSTER_SIZE = 'w342';

--- a/lib/movies.ts
+++ b/lib/movies.ts
@@ -1,8 +1,6 @@
 import { supabaseAdminClient } from './supabaseAdminClient';
 import { getMovieItemTypeId } from './itemTypes';
 
-export const MOVIE_POSTER_SIZE = 'w342';
-
 export type MovieRecord = {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- add an authenticated "My ratings" navigation entry and page for browsing personal Elo scores
- expose API routes to fetch the current user's groups and per-movie ratings sorted within a group
- build a client explorer component that lets the user choose a group and review movies with ratings and comparison counts

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d196bb7578832eac79cc35d21068ac