### PR TITLE
Handle loading and signed-out states in navigation bar

### DIFF
--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -19,6 +19,8 @@ const NavigationBar = () => {
   const [sessionChecked, setSessionChecked] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isLoadingSession = !sessionChecked;
+  const isSignedIn = Boolean(userEmail);
 
   useEffect(() => {
     let isMounted = true;
@@ -96,10 +98,6 @@ const NavigationBar = () => {
     }
   };
 
-  if (!sessionChecked || !userEmail) {
-    return null;
-  }
-
   return (
     <div className="border-b border-gray-800 bg-gray-950/70 text-white backdrop-blur">
       <nav className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6">
@@ -107,36 +105,57 @@ const NavigationBar = () => {
           <Link href="/" className="text-lg font-semibold text-white transition hover:text-blue-400">
             MovElo
           </Link>
-          <div className="flex items-center gap-4 text-sm font-medium text-gray-300 sm:hidden">
-            {NAV_LINKS.map((link) => (
-              <Link key={link.href} href={link.href} className="transition hover:text-white">
-                {link.label}
-              </Link>
-            ))}
-          </div>
+          {isSignedIn ? (
+            <div className="flex items-center gap-4 text-sm font-medium text-gray-300 sm:hidden">
+              {NAV_LINKS.map((link) => (
+                <Link key={link.href} href={link.href} className="transition hover:text-white">
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          ) : null}
         </div>
         <div className="flex items-center justify-between gap-4 sm:justify-end">
-          <div className="hidden items-center gap-4 text-sm font-medium text-gray-300 sm:flex">
-            {NAV_LINKS.map((link) => (
-              <Link key={link.href} href={link.href} className="transition hover:text-white">
-                {link.label}
+          {isLoadingSession ? (
+            <div className="flex items-center gap-2 text-sm text-gray-400" aria-live="polite">
+              <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-blue-400" aria-hidden="true" />
+              <span>Checking session…</span>
+            </div>
+          ) : isSignedIn ? (
+            <>
+              <div className="hidden items-center gap-4 text-sm font-medium text-gray-300 sm:flex">
+                {NAV_LINKS.map((link) => (
+                  <Link key={link.href} href={link.href} className="transition hover:text-white">
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
+              <div className="hidden h-6 w-px bg-gray-800 sm:block" aria-hidden="true" />
+              <div className="flex items-center gap-3">
+                <span className="hidden text-sm text-gray-400 sm:inline" title={userEmail ?? undefined}>
+                  {userEmail}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleSignOut}
+                  disabled={signingOut}
+                  className="rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  {signingOut ? 'Signing out…' : 'Sign out'}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center gap-3">
+              <span className="hidden text-sm text-gray-400 sm:inline">Sign in to access your rankings.</span>
+              <Link
+                href="/"
+                className="inline-flex items-center rounded-md bg-blue-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              >
+                Sign in
               </Link>
-            ))}
-          </div>
-          <div className="hidden h-6 w-px bg-gray-800 sm:block" aria-hidden="true" />
-          <div className="flex items-center gap-3">
-            <span className="hidden text-sm text-gray-400 sm:inline" title={userEmail ?? undefined}>
-              {userEmail}
-            </span>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              disabled={signingOut}
-              className="rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {signingOut ? 'Signing out…' : 'Sign out'}
-            </button>
-          </div>
+            </div>
+          )}
         </div>
       </nav>
       {error ? (


### PR DESCRIPTION
## Summary
- always render the navigation bar container and derive session flags for loading and signed-in states
- show a pending session indicator and sign-in call-to-action while preserving the existing menu for authenticated users

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c2c02630832eb10f8b33e0c11cd6