### PR TITLE
Rename site to Prefelo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MovElo
+# Prefelo
 
-MovElo helps you build a personal movie ranking by comparing films head-to-head. The homepage now includes Supabase powered
+Prefelo helps you build a personal movie ranking by comparing films head-to-head. The homepage now includes Supabase powered
 registration and login so you can save progress across devices.
 
 ## Prerequisites

--- a/app/components/HomePage.tsx
+++ b/app/components/HomePage.tsx
@@ -10,9 +10,9 @@ const HomePage = () => {
       <main className="flex flex-1 items-center justify-center px-4 py-12">
         <div className="flex w-full max-w-5xl flex-col items-center gap-10 md:flex-row md:items-start md:justify-between">
           <div className="max-w-2xl text-center md:text-left">
-            <h1 className="text-5xl font-bold md:text-6xl">Welcome to MovElo</h1>
+            <h1 className="text-5xl font-bold md:text-6xl">Welcome to Prefelo</h1>
             <p className="mt-4 text-lg text-gray-200 md:text-xl">
-              MovElo is your personal movie ranking companion. Compare your favorite films to build a definitive list that
+              Prefelo is your personal movie ranking companion. Compare your favorite films to build a definitive list that
               reflects your taste.
             </p>
             <p className="mt-4 text-base text-gray-300">

--- a/app/components/NavigationBar.tsx
+++ b/app/components/NavigationBar.tsx
@@ -103,7 +103,7 @@ const NavigationBar = () => {
       <nav className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:px-6">
         <div className="flex items-center justify-between gap-4 sm:justify-start">
           <Link href="/" className="text-lg font-semibold text-white transition hover:text-blue-400">
-            MovElo
+            Prefelo
           </Link>
           {isSignedIn ? (
             <div className="flex items-center gap-4 text-sm font-medium text-gray-300 sm:hidden">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "MovElo",
-  description: "Compare movies head-to-head and build a personal ranking.",
+  title: "Prefelo",
+  description: "Prefelo lets you compare movies head-to-head and build a personal ranking.",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- rename on-site branding and metadata to use the Prefelo name
- update the README to reference the new Prefelo brand

## Testing
- `npm run build` *(fails: Next.js could not download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ccca4f7c832eafecd39c287ee831